### PR TITLE
Tweak coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+[run]
+branch = True
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit = xgcm/test/*
+       xgcm/__init__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,19 @@ before_install:
 install:
   - conda env create --file ci/environment-$CONDA_ENV.yml
   - source activate test_env
-  - python setup.py install
+# if we do this, the package gets installed into
+# /home/travis/build/xgcm/xgcm/build/lib/xgcm
+#  - python setup.py install
+  - pip install -e .
+# this puts the package into
+# /home/travis/build/xgcm/xgcm/xgcm
+# That turns out to be necessary for py.test to correctly collect the tests
+# and for coverage to work properly.
+# It is very complicated and confusing.
 
 script:
-  - py.test xgcm --cov=xgcm --cov-report term-missing
+  - py.test xgcm --cov=xgcm --cov-config .coveragerc --cov-report term-missing
+#  - py.test -v
 
 after_success:
-  - coveralls
+  - codecov

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # xgcm
 
 [![Build Status](https://travis-ci.org/xgcm/xgcm.svg?branch=master)](https://travis-ci.org/xgcm/xgcm)
+[![codecov.io](https://codecov.io/github/xgcm/xgcm/coverage.svg?branch=master)](https://codecov.io/github/xgcm/xgcm?branch=master)
 
 xgcm is a python package for analyzing general circulation model (GCM) output data.
 xgcm is built on top of [xray](http://github.com/xray/xray).
 
-xgcm is motivated by the fact that our models are getting bigger and 
+xgcm is motivated by the fact that our models are getting bigger and
 [bigger](http://maps.actualscience.net/MITgcm_llc_maps/llc_4320/),
 and we are in desperate need of some scalable analysis tools.
 

--- a/ci/environment-py27-xray06.yml
+++ b/ci/environment-py27-xray06.yml
@@ -6,5 +6,5 @@ dependencies:
   - numpy
   - pytest
   - pip:
-    - coveralls
+    - codecov
     - pytest-cov

--- a/ci/environment-py27.yml
+++ b/ci/environment-py27.yml
@@ -6,5 +6,5 @@ dependencies:
   - numpy
   - pytest
   - pip:
-    - coveralls
+    - codecov
     - pytest-cov

--- a/ci/environment-py34.yml
+++ b/ci/environment-py34.yml
@@ -6,5 +6,5 @@ dependencies:
   - numpy
   - pytest
   - pip:
-    - coveralls
+    - codecov
     - pytest-cov

--- a/ci/environment-py35-xray06.yml
+++ b/ci/environment-py35-xray06.yml
@@ -6,5 +6,5 @@ dependencies:
   - numpy
   - pytest
   - pip:
-    - coveralls
+    - codecov
     - pytest-cov

--- a/ci/environment-py35.yml
+++ b/ci/environment-py35.yml
@@ -6,5 +6,5 @@ dependencies:
   - numpy
   - pytest
   - pip:
-    - coveralls
+    - codecov
     - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ CLASSIFIERS = [
 
 INSTALL_REQUIRES = ['xray']
 SETUP_REQUIRES = ['pytest-runner']
-TESTS_REQUIRE = ['pytest >= 2.8']
+TESTS_REQUIRE = ['pytest >= 2.8', 'coverage']
 
 if sys.version_info[:2] < (2, 7):
     TESTS_REQUIRE += ["unittest2 == 0.5.1"]


### PR DESCRIPTION
Will this work?

Running the test and coverage report on my laptop produces the following output

```bash
$ py.test xgcm --cov=xgcm --cov-config .coveragerc --cov-report term-missing
=========================================================== test session starts ============================================================
platform darwin -- Python 2.7.11, pytest-2.8.5, py-1.4.31, pluggy-0.3.1
rootdir: /Users/rpa/RND/Public/xgcm, inifile: 
plugins: cov-2.2.0
collected 4 items 

xgcm/test/test_gcm_dataset.py ....
--------------------------------------------- coverage: platform darwin, python 2.7.11-final-0 ---------------------------------------------
Name                 Stmts   Miss  Cover   Missing
--------------------------------------------------
xgcm/gridops.py        107     14    87%   9-10, 53, 55, 57, 92-95, 103, 260, 266, 289, 301
xgcm/mdsxray.py        275    233    15%   146-175, 184-195, 214-268, 279-313, 319-363, 368, 372, 376-378, 389-402, 409, 417, 421, 424-425, 435-444, 458-607, 611, 614, 617, 620
xgcm/regridding.py      42     37    12%   12-27, 34-72
--------------------------------------------------
TOTAL                  424    284    33%   

========================================================= 4 passed in 0.68 seconds =========================================================
```