### PR TITLE
Coords refactor

### DIFF
--- a/xgcm/comodo.py
+++ b/xgcm/comodo.py
@@ -91,7 +91,7 @@ def get_axis_positions_and_coords(ds, axis_name):
 
     # now we can start filling in the information about the different coords
     axis_coords = OrderedDict()
-    axis_coords['center'] = coords[center_coord_name]
+    axis_coords['center'] = center_coord_name
 
     # now check the other coords
     coord_names.remove(center_coord_name)
@@ -99,19 +99,19 @@ def get_axis_positions_and_coords(ds, axis_name):
         shift = axis_shift[name]
         clen = coord_len[name]
         if clen == axis_len + 1:
-            axis_coords['outer'] = coords[name]
+            axis_coords['outer'] = name
         elif clen == axis_len - 1:
-            axis_coords['inner'] = coords[name]
+            axis_coords['inner'] = name
         elif shift == -0.5:
             if clen == axis_len:
-                axis_coords['left'] = coords[name]
+                axis_coords['left'] = name
             else:
                 raise ValueError("Left coordinate %s has incompatible "
                                  "length %g (axis_len=%g)"
                                  % (name, clen, axis_len))
         elif shift == 0.5:
             if clen == axis_len:
-                axis_coords['right'] = coords[name]
+                axis_coords['right'] = name
             else:
                 raise ValueError("Right coordinate %s has incompatible "
                                  "length %g (axis_len=%g)"

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -619,8 +619,8 @@ class Axis:
                 # only add coordinate if it actually exists
                 # otherwise this creates a new coordinate where before there
                 # was none
-                if new_dim in self.ds.coords:
-                    coords[new_dim] = self.ds.coords[new_dim]
+                if new_dim in self._ds.coords:
+                    coords[new_dim] = self._ds.coords[new_dim]
             else:
                 dims.append(d)
                 # only add coordinate if it actually exists...
@@ -636,7 +636,7 @@ class Axis:
         for position, coord_name in iteritems(self.coords):
             # TODO: should we have more careful checking of alignment here?
             if coord_name in da.dims:
-                return position, coord.name
+                return position, coord_name
 
         raise KeyError("None of the DataArray's dims %s were found in axis "
                        "coords." % repr(da.dims))

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -91,18 +91,14 @@ def test_create_axis(all_datasets):
         this_axis = axis_objs[ax_expected]
         for axis_name, coord_name in coords_expected.items():
             assert axis_name in this_axis.coords
-            assert this_axis.coords[axis_name].name == coord_name
+            assert this_axis.coords[axis_name] == coord_name
 
 
 def _assert_axes_equal(ax1, ax2):
     assert ax1.name == ax2.name
     for pos, coord in ax1.coords.items():
         assert pos in ax2.coords
-        this_coord = ax2.coords[pos]
-        print('PRINTING COORDS')
-        print(coord)
-        print(this_coord)
-        assert coord.equals(this_coord)
+        assert coord == ax2.coords[pos]
     assert ax1._periodic == ax2._periodic
     assert ax1._default_shifts == ax2._default_shifts
     assert ax1._facedim == ax2._facedim
@@ -126,9 +122,9 @@ def test_create_axis_no_comodo(all_datasets):
         ax1 = axis_objs[axis_name]
 
         assert ax1.name == ax2.name
-        for pos, coord in ax1.coords.items():
+        for pos, coord_name in ax1.coords.items():
             assert pos in ax2.coords
-            assert coord.equals(ax2.coords[pos])
+            assert coord_name == ax2.coords[pos]
         assert ax1._periodic == ax2._periodic
         assert ax1._default_shifts == ax2._default_shifts
         assert ax1._facedim == ax2._facedim
@@ -149,7 +145,6 @@ def test_create_axis_no_coords(all_datasets):
         assert ax1.name == ax2.name
         for pos, coord in ax1.coords.items():
             assert pos in ax2.coords
-            print(ax2.coords[pos])
         assert ax1._periodic == ax2._periodic
         assert ax1._default_shifts == ax2._default_shifts
         assert ax1._facedim == ax2._facedim
@@ -169,8 +164,8 @@ def test_get_axis_coord(all_datasets):
     for ax_name, axis in axis_objs.items():
         # create a dataarray with each axis coordinate
         for position, coord in axis.coords.items():
-            da = 1 * ds[coord.name]
-            assert axis._get_axis_coord(da) == (position, coord.name)
+            da = 1 * ds[coord]
+            assert axis._get_axis_coord(da) == (position, coord)
 
 
 def test_axis_wrap_and_replace_2d(periodic_2d):
@@ -435,7 +430,7 @@ def test_axis_diff_and_interp_nonperiodic_2d(all_2d, boundary, axis_name,
     # everything is left shift
     data = ds[varname].data
 
-    axis_num = da.get_axis_num(axis.coords[this].name)
+    axis_num = da.get_axis_num(axis.coords[this])
     print(axis_num, ax_periodic)
 
     # lookups for numpy.pad
@@ -475,7 +470,7 @@ def test_axis_diff_and_interp_nonperiodic_2d(all_2d, boundary, axis_name,
 
     # determine new dims
     dims = list(da.dims)
-    dims[axis_num] = axis.coords[to].name
+    dims[axis_num] = axis.coords[to]
     coords = {dim: ds[dim] for dim in dims}
 
     da_interp_expected = xr.DataArray(data_interp, dims=dims, coords=coords)

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -99,6 +99,9 @@ def _assert_axes_equal(ax1, ax2):
     for pos, coord in ax1.coords.items():
         assert pos in ax2.coords
         this_coord = ax2.coords[pos]
+        print('PRINTING COORDS')
+        print(coord)
+        print(this_coord)
         assert coord.equals(this_coord)
     assert ax1._periodic == ax2._periodic
     assert ax1._default_shifts == ax2._default_shifts
@@ -110,7 +113,6 @@ def _assert_axes_equal(ax1, ax2):
 def test_create_axis_no_comodo(all_datasets):
     ds, periodic, expected = all_datasets
     axis_objs = _get_axes(ds)
-    print(axis_objs)
 
     # now strip out the metadata
     ds_noattr = ds.copy()
@@ -119,12 +121,38 @@ def test_create_axis_no_comodo(all_datasets):
 
     for axis_name, axis_coords in expected['axes'].items():
         # now create the axis from scratch with no attributes
-        this_axis = Axis(ds_noattr, axis_name, coords=axis_coords)
-        axis_expected = axis_objs[axis_name]
-        # make sure all the same stuff is present in both all_axes
-        # TODO: come up with a more general way to assert axis equality
-        _assert_axes_equal(axis_expected, this_axis)
+        ax2 = Axis(ds_noattr, axis_name, coords=axis_coords)
+        # and compare to the one created with attributes
+        ax1 = axis_objs[axis_name]
 
+        assert ax1.name == ax2.name
+        for pos, coord in ax1.coords.items():
+            assert pos in ax2.coords
+            assert coord.equals(ax2.coords[pos])
+        assert ax1._periodic == ax2._periodic
+        assert ax1._default_shifts == ax2._default_shifts
+        assert ax1._facedim == ax2._facedim
+
+
+def test_create_axis_no_coords(all_datasets):
+    ds, periodic, expected = all_datasets
+    axis_objs = _get_axes(ds)
+
+    ds_drop = ds.drop(list(ds.coords))
+
+    for axis_name, axis_coords in expected['axes'].items():
+        # now create the axis from scratch with no attributes OR coords
+        ax2 = Axis(ds_drop, axis_name, coords=axis_coords)
+        # and compare to the one created with attributes
+        ax1 = axis_objs[axis_name]
+
+        assert ax1.name == ax2.name
+        for pos, coord in ax1.coords.items():
+            assert pos in ax2.coords
+            print(ax2.coords[pos])
+        assert ax1._periodic == ax2._periodic
+        assert ax1._default_shifts == ax2._default_shifts
+        assert ax1._facedim == ax2._facedim
 
 def test_axis_repr(all_datasets):
     ds, periodic, expected = all_datasets

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -553,6 +553,23 @@ def test_create_grid_no_comodo(all_datasets):
         _assert_axes_equal(axis_expected, axis_actual)
 
 
+def test_grid_no_coords(periodic_1d):
+
+    ds, periodic, expected = periodic_1d
+    grid_expected = Grid(ds, periodic=periodic)
+
+    ds_nocoords = ds.drop(list(ds.dims.keys()))
+
+    coords = expected['axes']
+    grid = Grid(ds_nocoords, periodic=periodic, coords=coords)
+
+    diff = grid.diff(ds['data_c'], 'X')
+    assert len(diff.coords) == 0
+    interp = grid.interp(ds['data_c'], 'X')
+    assert len(interp.coords) == 0
+
+
+
 def test_grid_repr(all_datasets):
     ds, periodic, expected = all_datasets
     grid = Grid(ds, periodic=periodic)


### PR DESCRIPTION
When I started xgcm, xarray did not support dimensions without coordinates. Once that possibility was added to xarray, it created #110: xgcm would spuriously add coordinates when doing grid operations. That is because we would try to access the coordinates like `ds.coords['XG']`; for some reason, xarray returns a `DataArray` for this, even if `XG` is not a coordinate, i.e. `'XG' not in ds.coords`.

To fix this, here I refactor the internal design of xgcm a little bit. Axis objects need to keep track of the dimensions associated to center, left, right, etc. This done in a dictionary called `.coords`. Before we stored an actual xarray.DataArray object, like `axis.coords = {'left': xarray.DataArray}`. With this pr, instead we do `axis.coords = {'left': 'XG'}`, were XG is the name of the dimension.

