### PR TITLE
Changed ci env names to unique name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 
 install:
   - conda env create --file ci/environment-$CONDA_ENV.yml
-  - source activate test_env
+  - source activate test_env_xgcm
 # if we do this, the package gets installed into
 # /home/travis/build/xgcm/xgcm/build/lib/xgcm
 #  - python setup.py install

--- a/ci/environment-py27.yml
+++ b/ci/environment-py27.yml
@@ -1,4 +1,4 @@
-name: test_env
+name: test_env_xgcm
 dependencies:
   - python=2.7
   - xarray

--- a/ci/environment-py35.yml
+++ b/ci/environment-py35.yml
@@ -1,4 +1,4 @@
-name: test_env
+name: test_env_xgcm
 dependencies:
   - python=3.5
   - xarray

--- a/ci/environment-py36.yml
+++ b/ci/environment-py36.yml
@@ -1,4 +1,4 @@
-name: test_env
+name: test_env_xgcm
 dependencies:
   - python=3.6
   - xarray


### PR DESCRIPTION
I ran into problems when working on xarray and xgcm PRs since both use the name `test_env` for their environments. This gives our conda env the unique name `test_env_xgcm` so folks dont have to reinstall environments when switching between the packages.

Addresses #134 
