### PR TITLE
Use web.archive link for pycomodo docs

### DIFF
--- a/doc/grids.rst
+++ b/doc/grids.rst
@@ -21,7 +21,7 @@ conservation properties.
 
   Layout of variables with respect to cell centers and edges in a C-grid
   ocean model. Image from the
-  `pycomodo project <http://pycomodo.forge.imag.fr/norm.html>`_.
+  `pycomodo project <https://web.archive.org/web/20160417032300/http://pycomodo.forge.imag.fr/norm.html>`_.
 
 These grids present a dilemma for the `xarray`_ data model. The ``u`` and ``t``
 points in the example above are located at different points along the x-axis,
@@ -297,4 +297,4 @@ This is described in the :ref:`grid_topology` page.
 .. _xarray: http://xarray.pydata.org
 .. _MITgcm notation: http://mitgcm.org/public/r2_manual/latest/online_documents/node31.html
 .. _CF Conventions: http://cfconventions.org/
-.. _COMODO Conventions: http://pycomodo.forge.imag.fr/norm.html
+.. _COMODO Conventions: https://web.archive.org/web/20160417032300/http://pycomodo.forge.imag.fr/norm.html

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -78,7 +78,7 @@ class Axis:
 
         REFERENCES
         ----------
-        .. [1] Comodo Conventions http://pycomodo.forge.imag.fr/norm.html
+        .. [1] Comodo Conventions https://web.archive.org/web/20160417032300/http://pycomodo.forge.imag.fr/norm.html
         """
 
         self._ds = ds
@@ -803,7 +803,7 @@ class Grid:
 
         REFERENCES
         ----------
-        .. [1] Comodo Conventions http://pycomodo.forge.imag.fr/norm.html
+        .. [1] Comodo Conventions https://web.archive.org/web/20160417032300/http://pycomodo.forge.imag.fr/norm.html
         """
         self._ds = ds
         self._check_dims = check_dims

--- a/xgcm/test/datasets.py
+++ b/xgcm/test/datasets.py
@@ -5,7 +5,7 @@ import xarray as xr
 import numpy as np
 
 # example from comodo website
-# http://pycomodo.forge.imag.fr/norm.html
+# https://web.archive.org/web/20160417032300/http://pycomodo.forge.imag.fr/norm.html
 # netcdf example {
 #         dimensions:
 #                 ni = 9 ;


### PR DESCRIPTION
The original website with the Comodo conventions that are cited in the docs is gone: <http://pycomodo.forge.imag.fr>

This PR changes all links to the comodo project to the web.archive.

Closes #119 