### PR TITLE
Add note in documentation on reversing `cumint` direction

### DIFF
--- a/doc/grid_metrics.ipynb
+++ b/doc/grid_metrics.ipynb
@@ -498,7 +498,10 @@
     "grid.cumsum( -grid.integrate(ds.UVEL,'Z') * ds.dyG, 'Y', boundary='fill')\n",
     "```\n",
     "\n",
-    "Except that, once again, one does not have to remember the matching metric while using `cumint`."
+    "Except that, once again, one does not have to remember the matching metric while using `cumint`.",
+    "\n",
+    "To reverse the integral bounds you can reindex the coordinate along which the cumulative integral\n",
+    "is to be evaluated for example, with `ds.reindex(Z=ds.Z[::-1], Zl=ds.Zl[::-1])` before calling `cumint`."
    ]
   },
   {


### PR DESCRIPTION
Had to calculate a cumulative integral from the bottom up but documentation did not provide any hints on how to do this so this PR adds a sentence in case other users would like to do the same.

I just had to do `ds = ds.reindex(Z=ds.Z[::-1], Zl=ds.Zl[::-1])`.

Hint from https://stackoverflow.com/questions/54677161/xarray-reverse-an-array-along-one-coordinate

I edited the Jupyter notebook doc directly to avoid modifying a ton of Jupyter metadata.

I'm computing geostrophic velocity profiles from thermal wind balance if anyone is interested: https://github.com/ali-ramadhan/LESbrary.jl/blob/3041967c8bea4b4a58d7a208d6db1fbece591078/src/sose_data.py#L64-L115