### PR TITLE
WIP: add xarray dataarray_accessor

### DIFF
--- a/xgcm/__init__.py
+++ b/xgcm/__init__.py
@@ -5,3 +5,4 @@ del get_versions
 
 from .grid import Grid, Axis
 from .autogenerate import generate_grid_ds
+from .accessor import GridAccessor

--- a/xgcm/accessor.py
+++ b/xgcm/accessor.py
@@ -1,0 +1,39 @@
+import xarray as xr
+
+from .grid import Grid, _get_global_grids
+
+
+class GridError(Exception):
+    pass
+
+
+def _find_compatible_global_grid(da):
+    global_grids = _get_global_grids()
+    for grid in global_grids:
+        try:
+            xr.align(grid._ds, da, join="exact")
+            return grid
+        except ValueError:
+            pass
+    raise GridError("No compatible global grid found.")
+
+
+@xr.register_dataarray_accessor("grid")
+class GridAccessor:
+    def __init__(self, xarray_obj):
+        self._da = xarray_obj
+        self._grid_obj = None
+        self.init()
+
+    def init(self, grid_obj=None):
+        """Initialize xgcm.Grid object for the dataset."""
+        if grid_obj:
+            self._grid_obj = grid_obj
+        else:
+            self._grid_obj = _find_compatible_global_grid(self._da)
+
+    def interp(self, *args, **kwargs):
+        return self._grid_obj.interp(self._da, *args, **kwargs)
+
+    def diff(self, *args, **kwargs):
+        return self._grid_obj.diff(self._da, *args, **kwargs)

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -9,11 +9,26 @@ import operator
 import docrep
 import xarray as xr
 import numpy as np
+import weakref
 
 from . import comodo
 from .duck_array_ops import _pad_array, _apply_boundary_condition, concatenate
 
 docstrings = docrep.DocstringProcessor(doc_key="My doc string")
+
+_global_grids = weakref.WeakSet()
+
+
+def _get_global_grids():
+    return _global_grids
+
+
+def _add_to_global_grids(grid):
+    _global_grids.add(grid)
+
+
+def _clear_global_grids():
+    _global_grids.clear()
 
 
 def _maybe_promote_str_to_list(a):
@@ -836,6 +851,8 @@ class Grid:
 
         if metrics is not None:
             self._assign_metrics(metrics)
+
+        _add_to_global_grids(self)
 
     def _parse_axes_kwargs(self, kwargs):
         """Convvert kwarg input into dict for each available axis


### PR DESCRIPTION
This is something we have discussed for a while. Today I realized it was pretty simple to implement. (Famous last words.) So I had to give it a try.

Several people (e.g. @JiaweiZhuang) have commented that they would like to be able to use xgcm with an accessor. The challenge is figuring out which Grid object to use with any given xarray.DataArray.

What I did here was copy Dask's mechanism for finding a Client object to use for computation. I used [weakref](https://docs.python.org/3/library/weakref.html) to create a global set of Grid objects. When you access the `.grid` property of a DataArray, the accessor searches for a Grid that can align with the DataArray. The first one it finds is used for `da.grid.interp` and `da.grid.diff` methods.

Here's a simple example:

```python
import numpy as np
import xarray as xr
import xgcm

ds = xr.Dataset(coords={'x_c': (['x_c',], np.arange(1,10)),
                        'x_g': (['x_g',], np.arange(0.5,9))})

grid = xgcm.Grid(ds, coords={'X': {'center': 'x_c', 'left': 'x_g'}})
da = np.cos(ds.x_c)
da.grid.interp('X')
```

There are many ways this could go wrong, particularly if there are multiple Grid objects in existence. However, in my workflows I tend to only ever have one at a time. So perhaps it's a easy, simple solution that will improve our API.