### PR TITLE
prep for 0.5.0

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -3,14 +3,15 @@
 What's New
 ===========
 
-v0.5.0 (unreleased)
+v0.5.0 (2020/9/28)
 -------------------------
-
 
 New Features
 ~~~~~~~~~~~~
 - :py:meth:`~xgcm.grid.Grid.transform` and :py:meth:`~xgcm.grid.Axis.transform` now enable 1-dimensional coordinate transformation (:pull:`205`, :issue:`222`).
   By `Ryan Abernathey <https://github.com/rabernat>`_ and `Julius Busecke <https://github.com/jbusecke>`_.
+  
+.. _whats-new.0.5.0:
 
 
 v0.4.0 (2020/9/2)


### PR DESCRIPTION
Closes #248 

I am prepping to release a new version of xgcm to make it easier to access the new `transform` functionality (and get it onto pangeo cloud). 

I think we have everything covered with this PR. Or is there something else that I should adjust before tagging `v0.5.0`?
EDIT: Its `0.5.0` not `0.6.0` as previously in the title.
