### PR TITLE
WIP: Implement `reverse` for cumsum method

### DIFF
--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -336,6 +336,21 @@ def test_axis_cumsum(nonperiodic_1d, boundary):
 
 
 @pytest.mark.parametrize(
+    "boundary", ["extend", "fill", pytest.param("extrapolate", marks=pytest.mark.xfail)]
+)
+@pytest.mark.parametrize("variable", ["data_g", "data_c"])
+def test_axis_cumsum_reverse(nonperiodic_1d, boundary, variable):
+    ds, periodic, expected = nonperiodic_1d
+    axis = Axis(ds, "X", periodic=periodic)
+    da = ds[variable]
+
+    _, dim = axis._get_axis_coord(da)
+    reverse_expected = da.sum(dim).data - axis.cumsum(da, boundary=boundary)
+    reverse = axis.cumsum(da, reverse=True, boundary=boundary)
+    xr.testing.assert_allclose(reverse_expected, reverse)
+
+
+@pytest.mark.parametrize(
     "varname, axis_name, to, roll, roll_axis, swap_order",
     [
         ("data_c", "X", "left", 1, 1, False),


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #184
 - [x] Tests added
 - [x] Passes `black . `
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`

I have attempted to implement a reversed cumulative sum. The method flips the `.data` along the relevant axis, then applies the cumulative sum, and flips the data back.

As a test case I expect the result to be equivalent to `da.sum(axis_dim) - grid.cumsum(axis)`.

Some cases pass  (outer/inner coords; except with `extent` boundary), but others do not. Still working on understanding where this goes wrong. 