### PR TITLE
Fix missing values handling average

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,6 +13,8 @@ New Features
   
 Bug fixes
 ~~~~~~~~~
+- More reliable handling of missing values in :py:meth:`Grid.average`. Missing values between data and metrics do not have to be aligned by the user anymore. (:pull:`259`). By `Julius Busecke <https://github.com/jbusecke>`_.
+
 - Remove outdated `example_notebooks` folder (:pull:`244`, :issue:`243`). By `Nikolay Koldunov <https://github.com/koldunovn>`_ and `Julius Busecke <https://github.com/jbusecke>`_.
 .. _whats-new.0.5.0:
 

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1712,24 +1712,21 @@ class Grid:
         axis : str, list of str
             Name of the axis on which to act
         **kwargs: dict
-            Additional arguments passed to `xarray.DataArray.sum`
-
+            Additional arguments passed to `xarray.DataArray.weighted.mean`
 
         Returns
         -------
         da_i : xarray.DataArray
             The averaged data
         """
-
+        da = da.copy()
         weight = self.get_metric(da, axis)
-        weighted = da * weight
-        # TODO: We should integrate xarray.weighted once available.
+        weighted = da.weighted(weight)
 
         # get dimension(s) corresponding
         # to `da` and `axis` input
         dim = self._get_dims_from_axis(da, axis)
-        # do we need to pass kwargs?
-        return weighted.sum(dim, **kwargs) / weight.sum(dim, **kwargs)
+        return weighted.mean(dim, **kwargs)
 
     def transform(self, da, axis, target, **kwargs):
         """Convert an array of data to new 1D-coordinates along `axis`.

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1719,7 +1719,6 @@ class Grid:
         da_i : xarray.DataArray
             The averaged data
         """
-        da = da.copy()
         weight = self.get_metric(da, axis)
         weighted = da.weighted(weight)
 

--- a/xgcm/test/test_metric_ops_multi_axis.py
+++ b/xgcm/test/test_metric_ops_multi_axis.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import pytest
+import xarray as xr
 
 from xgcm.grid import Grid
 from xgcm.test.datasets import datasets_grid_metric

--- a/xgcm/test/test_metric_ops_multi_axis.py
+++ b/xgcm/test/test_metric_ops_multi_axis.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import pytest
 import xarray as xr
+from xarray.testing import assert_allclose
 
 from xgcm.grid import Grid
 from xgcm.test.datasets import datasets_grid_metric
@@ -51,12 +52,12 @@ class TestParametrized:
             expected = _expected_result(
                 ds.tracer, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            xr.testing.assert_allclose(new, expected)
+            assert_allclose(new, expected)
 
             # test with tuple input if list is provided
             if isinstance(axis, list):
                 new = func(ds.tracer, tuple(axis), **kwargs)
-                xr.testing.assert_allclose(new, expected)
+                assert_allclose(new, expected)
 
         # test u position
         for axis, metric_name, dim in zip(
@@ -68,7 +69,7 @@ class TestParametrized:
             expected = _expected_result(
                 ds.u, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            xr.testing.assert_allclose(new, expected)
+            assert_allclose(new, expected)
 
         # test v position
         for axis, metric_name, dim in zip(
@@ -80,7 +81,7 @@ class TestParametrized:
             expected = _expected_result(
                 ds.v, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            xr.testing.assert_allclose(new, expected)
+            assert_allclose(new, expected)
 
     def test_cgrid(self, funcname, boundary, periodic):
         ds, coords, metrics = datasets_grid_metric("C")
@@ -105,11 +106,11 @@ class TestParametrized:
             expected = _expected_result(
                 ds.tracer, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            xr.testing.assert_allclose(new, expected)
+            assert_allclose(new, expected)
             # test with tuple input if list is provided
             if isinstance(axis, list):
                 new = func(ds.tracer, tuple(axis), **kwargs)
-                xr.testing.assert_allclose(new, expected)
+                assert_allclose(new, expected)
 
         # test u positon
         for axis, metric_name, dim in zip(
@@ -121,7 +122,7 @@ class TestParametrized:
             expected = _expected_result(
                 ds.u, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            xr.testing.assert_allclose(new, expected)
+            assert_allclose(new, expected)
 
         # test v positon
         for axis, metric_name, dim in zip(
@@ -133,7 +134,7 @@ class TestParametrized:
             expected = _expected_result(
                 ds.v, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            xr.testing.assert_allclose(new, expected)
+            assert_allclose(new, expected)
 
     @pytest.mark.parametrize("axis", ["X", "Y", "Z"])
     def test_missingaxis(self, axis, funcname, periodic, boundary):

--- a/xgcm/test/test_metric_ops_multi_axis.py
+++ b/xgcm/test/test_metric_ops_multi_axis.py
@@ -50,12 +50,12 @@ class TestParametrized:
             expected = _expected_result(
                 ds.tracer, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            assert new.equals(expected)
+            xr.testing.assert_allclose(new, expected)
 
             # test with tuple input if list is provided
             if isinstance(axis, list):
                 new = func(ds.tracer, tuple(axis), **kwargs)
-                assert new.equals(expected)
+                xr.testing.assert_allclose(new, expected)
 
         # test u position
         for axis, metric_name, dim in zip(
@@ -67,7 +67,7 @@ class TestParametrized:
             expected = _expected_result(
                 ds.u, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            assert new.equals(expected)
+            xr.testing.assert_allclose(new, expected)
 
         # test v position
         for axis, metric_name, dim in zip(
@@ -79,7 +79,7 @@ class TestParametrized:
             expected = _expected_result(
                 ds.v, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            assert new.equals(expected)
+            xr.testing.assert_allclose(new, expected)
 
     def test_cgrid(self, funcname, boundary, periodic):
         ds, coords, metrics = datasets_grid_metric("C")
@@ -104,11 +104,11 @@ class TestParametrized:
             expected = _expected_result(
                 ds.tracer, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            assert new.equals(expected)
+            xr.testing.assert_allclose(new, expected)
             # test with tuple input if list is provided
             if isinstance(axis, list):
                 new = func(ds.tracer, tuple(axis), **kwargs)
-                assert new.equals(expected)
+                xr.testing.assert_allclose(new, expected)
 
         # test u positon
         for axis, metric_name, dim in zip(
@@ -120,7 +120,7 @@ class TestParametrized:
             expected = _expected_result(
                 ds.u, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            assert new.equals(expected)
+            xr.testing.assert_allclose(new, expected)
 
         # test v positon
         for axis, metric_name, dim in zip(
@@ -132,7 +132,7 @@ class TestParametrized:
             expected = _expected_result(
                 ds.v, ds[metric_name], grid, dim, axis, funcname, **kwargs
             )
-            assert new.equals(expected)
+            xr.testing.assert_allclose(new, expected)
 
     @pytest.mark.parametrize("axis", ["X", "Y", "Z"])
     def test_missingaxis(self, axis, funcname, periodic, boundary):

--- a/xgcm/test/test_metrics_ops_single_axis.py
+++ b/xgcm/test/test_metrics_ops_single_axis.py
@@ -108,6 +108,27 @@ def test_boundary_global_input(funcname, boundary, fill_value):
     xr.testing.assert_allclose(global_result, manual_result)
 
 
+def test_average_unmatched_missing():
+    # Tests the behavior of grid.average on an array which has missing values, not present in the metric
+    x = np.arange(10)
+    data = xr.DataArray(np.ones(10), dims="x", coords={"x": x})
+    weights = data * 30
+    ds = xr.Dataset({"data": data})
+    ds = ds.assign_coords(weights=weights)
+    # create an xgcm grid
+    grid = Grid(ds, coords={"X": {"center": "x"}}, metrics={"X": ["weights"]})
+
+    # average the unmasked array
+    expected = grid.average(ds.data, "X")
+
+    # now lets introduce a missing value in the data
+    ds.data[6:8] = np.nan
+
+    # assert that the result for both the full and the masked array is equal,
+    # since both only have ones in them.
+    xr.testing.assert_allclose(expected, grid.average(ds.data, "X"))
+
+
 def test_derivative_uniform_grid():
     # this is a uniform grid
     # a non-uniform grid would provide a more rigorous test


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Replaces #204 
 - [x] Tests added
 - [x] Passes `black . `
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

I totally messed up #204 and since the changes are minor, I decided to start over fresh. 

This PR replaces our internal logic for the weighted average with xarrays `weighted`. This prevents errors, which arise when the processed data has missing values which are not found in the metric needed for the operation. I have turned my simple example into a [test](https://github.com/jbusecke/xgcm/blob/ccf95f0cda304f9afd486dd9d14718944a6ca273/xgcm/test/test_metrics_ops_single_axis.py#L111-L129), which failed with the current version.

As mentioned in #204 this also allows to compute averages on subsets of the dataset (due to `weighted`'s internal alignment). This addresses #193, but I would like to treat is as a bugfix only, since we still need to discuss a more consistent handling of subsets with all available functions.
