### PR TITLE
add setuptools_scm on 3.8 but not others

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,6 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -e . --no-deps
-          python setup.py --version
           conda list
       - name: Run Tests
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,8 @@ jobs:
       - name: Set up conda environment
         shell: bash -l {0}
         run: |
-          python -m pip install -e . --no-deps --force-reinstall
+          python -m pip install -e . --no-deps
+          python setup.py --version
           conda list
       - name: Run Tests
         shell: bash -l {0}
@@ -76,7 +77,7 @@ jobs:
     - name: Set up conda environment
       shell: bash -l {0}
       run: |
-        python -m pip install -e . --no-deps --force-reinstall
+        python -m pip install -e . --no-deps
         conda list
     - name: Run Tests
       shell: bash -l {0}
@@ -106,7 +107,7 @@ jobs:
     - name: Set up conda environment
       shell: bash -l {0}
       run: |
-        python -m pip install -e . --no-deps --force-reinstall
+        python -m pip install -e . --no-deps
         conda list
     - name: Run Tests
       shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up conda environment
         shell: bash -l {0}
         run: |
-          python -m pip install -e .
+          python -m pip install -e . --no-deps --force-reinstall
           conda list
       - name: Run Tests
         shell: bash -l {0}
@@ -76,7 +76,7 @@ jobs:
     - name: Set up conda environment
       shell: bash -l {0}
       run: |
-        python -m pip install -e .
+        python -m pip install -e . --no-deps --force-reinstall
         conda list
     - name: Run Tests
       shell: bash -l {0}
@@ -106,7 +106,7 @@ jobs:
     - name: Set up conda environment
       shell: bash -l {0}
       run: |
-        python -m pip install -e .
+        python -m pip install -e . --no-deps --force-reinstall
         conda list
     - name: Run Tests
       shell: bash -l {0}

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -23,4 +23,6 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python setup.py sdist bdist_wheel
+          python setup.py --version
+          twine check dist/*
           twine upload dist/*

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -9,7 +9,6 @@ dependencies:
   - future
   - pip
   - black
-  - setuptools_scm
   - pip:
     - docrep<=0.2.7
     - codecov

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -9,6 +9,7 @@ dependencies:
   - future
   - pip
   - black
+  - setuptools_scm
   - pip:
     - docrep<=0.2.7
     - codecov


### PR DESCRIPTION
Just want to test if it is the lack of setuptools_scm or the pip install command with the chance of clobbering deps the culprit here.