### PR TITLE
Strict conda-forge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ jobs:
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-py${{ matrix.python-version }}.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          channels: conda-forge
+          channel-priority: strict
           activate-environment: test_env_xgcm # Defined in ci/environment*.yml
           auto-update-conda: false
           python-version: ${{ matrix.python-version }}
@@ -68,6 +70,8 @@ jobs:
         key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-core-deps.yml') }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
+        channels: conda-forge
+        channel-priority: strict
         activate-environment: test_env_xgcm # Defined in ci/environment-core-deps.yml
         auto-update-conda: false
         python-version: 3.8
@@ -98,6 +102,8 @@ jobs:
         key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-upstream-dev.yml') }}
     - uses: conda-incubator/setup-miniconda@v2
       with:
+        channels: conda-forge
+        channel-priority: strict
         activate-environment: test_env_xgcm # Defined in ci/environment-upstream-dev.yml
         auto-update-conda: false
         python-version: 3.8


### PR DESCRIPTION
I just saw these options in the [xarray ci](https://github.com/pydata/xarray/blob/7dbbdcafed7f796ab77039ff797bcd31d9185903/.github/workflows/ci.yaml#L67-L68). I think we should also strictly build from conda-forge?

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `black . `
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
