### PR TITLE
Fixing doctring for Neumann and Dirichlet

### DIFF
--- a/xgcm/duck_array_ops.py
+++ b/xgcm/duck_array_ops.py
@@ -58,9 +58,9 @@ def _apply_boundary_condition(da, dim, left, boundary=None, fill_value=0.0):
         A flag indicating how the boundary values are determined.
 
         * 'fill':  All values outside the array set to fill_value
-          (i.e. a Neumann boundary condition.)
+          (i.e. a Dirichlet boundary condition.)
         * 'extend': Set values outside the array to the nearest array
-          value. (i.e. a limited form of Dirichlet boundary condition.)
+          value. (i.e. a limited form of Neumann boundary condition.)
         * 'extrapolate': Set values by extrapolating linearly from the two
           points nearest to the edge
 
@@ -126,9 +126,9 @@ def _pad_array(da, dim, left=False, boundary=None, fill_value=0.0):
         * None:  Do not apply any boundary conditions. Raise an error if
           boundary conditions are required for the operation.
         * 'fill':  Set values outside the array boundary to fill_value
-          (i.e. a Neumann boundary condition.)
+          (i.e. a Dirichlet boundary condition.)
         * 'extend': Set values outside the array to the nearest array
-          value. (i.e. a limited form of Dirichlet boundary condition.)
+          value. (i.e. a limited form of Neumann boundary condition.)
 
     fill_value : float, optional
          The value to use in the boundary condition with `boundary='fill'`.

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -101,9 +101,10 @@ class Axis:
             * None:  Do not apply any boundary conditions. Raise an error if
               boundary conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
-              (i.e. a Neumann boundary condition.)
+              (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
-              value. (i.e. a limited form of Dirichlet boundary condition.)
+              value. (i.e. a limited form of Neumann boundary condition where
+              the difference at the boundary will be zero.)
             * 'extrapolate': Set values by extrapolating linearly from the two
               points nearest to the edge
             This sets the default value. It can be overriden by specifying the
@@ -259,9 +260,9 @@ class Axis:
             * None:  Do not apply any boundary conditions. Raise an error if
               boundary conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
-              (i.e. a Neumann boundary condition.)
+              (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
-              value. (i.e. a limited form of Dirichlet boundary condition.)
+              value. (i.e. a limited form of Neumann boundary condition.)
         fill_value : float, optional
             The value to use in the boundary condition with `boundary='fill'`.
         vector_partner : dict, optional
@@ -1082,9 +1083,9 @@ class Grid:
             * None:  Do not apply any boundary conditions. Raise an error if
               boundary conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
-              (i.e. a Neumann boundary condition.)
+              (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
-              value. (i.e. a limited form of Dirichlet boundary condition.)
+              value. (i.e. a limited form of Neumann boundary condition.)
             * 'extrapolate': Set values by extrapolating linearly from the two
               points nearest to the edge
             Optionally a dict mapping axis name to seperate values for each axis
@@ -1385,9 +1386,9 @@ class Grid:
             * None:  Do not apply any boundary conditions. Raise an error if
               boundary conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
-              (i.e. a Neumann boundary condition.)
+              (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
-              value. (i.e. a limited form of Dirichlet boundary condition.)
+              value. (i.e. a limited form of Neumann boundary condition.)
 
             Optionally a dict with seperate values for each axis can be passed (see example)
         fill_value : {float, dict}, optional


### PR DESCRIPTION
This PR closes #314 which fixes the docstring regarding the usage of the terms Neumann and Dirichlet. There are no new tests added as this PR only concerns the docstring.
