### PR TITLE
Install upstream `numba` with `conda`

### DIFF
--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -1,6 +1,8 @@
 # our test environment for core dependencies only (atm this excludes numba),
 # using the latest stable versions of packages.
 name: test_env_xgcm
+channels:
+  - conda-forge
 dependencies:
   - python=3.8
   - xarray

--- a/ci/environment-py3.6.yml
+++ b/ci/environment-py3.6.yml
@@ -1,4 +1,6 @@
 name: test_env_xgcm
+channels:
+  - conda-forge
 dependencies:
   - python=3.6
   - xarray

--- a/ci/environment-py3.7.yml
+++ b/ci/environment-py3.7.yml
@@ -1,4 +1,6 @@
 name: test_env_xgcm
+channels:
+  - conda-forge
 dependencies:
   - python=3.7
   - xarray

--- a/ci/environment-py3.8.yml
+++ b/ci/environment-py3.8.yml
@@ -1,4 +1,6 @@
 name: test_env_xgcm
+channels:
+  - conda-forge
 dependencies:
   - python=3.8
   - xarray

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -1,10 +1,12 @@
 name: test_env_xgcm
 channels:
-  - numba
+  # Get the latest numba from numba/label/dev
+  - numba/label/dev
+  - conda-forge
 dependencies:
   - python
   - numpy
-  - llvmlite
+  - numba
   - pytest
   - future
   - pip
@@ -18,4 +20,3 @@ dependencies:
     - git+https://github.com/dask/dask.git
     - git+https://github.com/dask/distributed.git
     - toolz
-    - git+https://github.com/numba/numba.git


### PR DESCRIPTION
Currently in the `upstream` CI build we install `numba` directly from GitHub:

https://github.com/xgcm/xgcm/blob/f2e1314b1468d46cc430af1d90878e6ff007f2d9/ci/environment-upstream-dev.yml#L21

Unfortunately this can lead to `pip` [installation issues](https://github.com/xgcm/xgcm/runs/2177597781) like

```
  ERROR: Could not find a version that satisfies the requirement llvmlite<0.38,>=0.37.0.dev0 (from numba)
  ERROR: No matching distribution found for llvmlite<0.38,>=0.37.0.dev0
```

when the development version of `numba` begins to rely on an unrelated version of `llvmlite`. Luckily the `numba` team maintains a nightly release which can be installed directly with `conda`. 

This PR updates the `upstream` CI build to use the nightly version of `conda`.

Additionally, I've also explicitly specified other CI builds should install packages from `conda-forge`. This isn't strictly necessary and can be removed from this PR if others prefer. 

 - [ ] ~~Closes #xxxx~~
 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [ ] ~~User visible changes (including notable bug fixes) are documented in `whats-new.rst`~~
 - [ ] ~~New functions/methods are listed in `api.rst`~~
