### PR TITLE
Improve input checks for grid.transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,16 @@ target/
 
 # notebook
 */.ipynb_checkpoints/*
+
+# vscode stuff
 .vscode/settings.json
+.vscode/launch.json
+
+# temporary dask stuff
+dask-worker-space/purge.lock
+dask-worker-space/global.lock
 dask-worker-space/dask-worker-space/global.lock
 dask-worker-space/dask-worker-space/purge.lock
-.vscode/launch.json
+
+# CI/Linting
+.mypy_cache

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -4,9 +4,14 @@ What's New
 ===========
 
 v0.6.0 (unreleased)
--------------------------
+-------------------
 
 .. _whats-new.0.6.0:
+
+Bug fixes
+~~~~~~~~~
+- Raise more useful errors when datasets are provided as arguments to grid.transform (:pull:`329`, :issue:`328`). By `Julius Busecke <https://github.com/jbusecke>`_.
+
 
 Documentation
 ~~~~~~~~~~~~~
@@ -15,16 +20,19 @@ Documentation
 
 
 v0.5.1 (2020/10/16)
--------------------------
+-------------------
+
+.. _whats-new.0.5.1:
 
 Bug fixes
 ~~~~~~~~~
 - Add support for older numba versions (<0.49) (:pull:`263`, :issue:`262`). By `Navid Constantinou <https://github.com/navidcy>`_.
-.. _whats-new.0.5.1:
+
 
 
 v0.5.0 (2020/9/28)
--------------------------
+------------------
+.. _whats-new.0.5.0:
 
 New Features
 ~~~~~~~~~~~~

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -874,10 +874,7 @@ class Axis:
             ("target", target, [xr.DataArray, np.ndarray]),
             ("target_data", target_data, [xr.DataArray]),
         ]:
-            if not (
-                any([isinstance(variable, ty) for ty in allowed_types])
-                or variable is None
-            ):
+            if not (isinstance(variable, tuple(allowed_types)) or variable is None):
                 raise ValueError(
                     f"`{var_name}` needs to be a {' or '.join([str(a) for a in allowed_types])}. Found {type(variable)}"
                 )

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -869,14 +869,17 @@ class Axis:
             )
 
         # complain if the target values are not provided as xr.dataarray
-        for var_name, variable in [
-            ("da", da),
-            ("target", target),
-            ("target_data", target_data),
+        for var_name, variable, allowed_types in [
+            ("da", da, [xr.DataArray]),
+            ("target", target, [xr.DataArray, np.ndarray]),
+            ("target_data", target_data, [xr.DataArray]),
         ]:
-            if not (isinstance(variable, xr.DataArray) or variable is None):
+            if not (
+                any([isinstance(variable, ty) for ty in allowed_types])
+                or variable is None
+            ):
                 raise ValueError(
-                    f"`{var_name}` needs to be a xr.DataArray. Found {type(variable)}"
+                    f"`{var_name}` needs to be a {' or '.join([str(a) for a in allowed_types])}. Found {type(variable)}"
                 )
 
         def _target_data_name_handling(target_data):

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -868,6 +868,17 @@ class Axis:
                 "`transform` can only be used on axes that are non-periodic. Pass `periodic=False` to `xgcm.Grid`."
             )
 
+        # complain if the target values are not provided as xr.dataarray
+        for var_name, variable in [
+            ("da", da),
+            ("target", target),
+            ("target_data", target_data),
+        ]:
+            if not (isinstance(variable, xr.DataArray) or variable is None):
+                raise ValueError(
+                    f"`{var_name}` needs to be a xr.DataArray. Found {type(variable)}"
+                )
+
         def _target_data_name_handling(target_data):
             """Handle target_data input without a name"""
             if target_data.name is None:

--- a/xgcm/test/test_transform.py
+++ b/xgcm/test/test_transform.py
@@ -1067,22 +1067,15 @@ def test_grid_transform_input_check():
     # Make sure that a sensible error is raised if xr.Dataset is provided
     # for either one of `source`, `target` or `target_data` input arguments.
 
-    err_msg = "transform only accepts xr.DataArray as input for `source`, `target` and `target_data`."
-
-    with pytest.raises(ValueError) as e_info:
+    with pytest.raises(ValueError, match=r"should be passed as xr.DataArray"):
         transformed = grid.transform(source, axis, target, **transform_kwargs)
-    assert str(e_info.value) == err_msg
-
-    with pytest.raises(ValueError) as e_info:
+    with pytest.raises(ValueError, match=r"should be passed as xr.DataArray"):
         transformed = grid.transform(
             source.data, axis, target.to_dataset(name="dummy"), **transform_kwargs
         )
-    assert str(e_info.value) == err_msg
-
     transform_kwargs["target_data"] = transform_kwargs["target_data"].to_dataset(
         name="dummy"
     )
-
-    with pytest.raises(ValueError) as e_info:
+    with pytest.raises(ValueError, match=r"should be passed as xr.DataArray"):
         transformed = grid.transform(source.data, axis, target, **transform_kwargs)
-    assert str(e_info.value) == err_msg
+    

--- a/xgcm/test/test_transform.py
+++ b/xgcm/test/test_transform.py
@@ -1066,7 +1066,7 @@ def test_grid_transform_input_check():
 
     # Make sure that a sensible error is raised if xr.Dataset is provided
     # for either one of `source`, `target` or `target_data` input arguments.
-    match_msg = r"needs to be a xr.DataArray. Found"
+    match_msg = r"needs to be a"
     with pytest.raises(ValueError, match=r"`da` " + match_msg):
         transformed = grid.transform(source, axis, target, **transform_kwargs)
 

--- a/xgcm/test/test_transform.py
+++ b/xgcm/test/test_transform.py
@@ -1047,6 +1047,7 @@ def test_chunking_dim_error():
         transformed = grid.transform(source.data, axis, target, **transform_kwargs)
 
 
+@pytest.mark.skipif(numba is None, reason="numba required")
 def test_grid_transform_input_check():
     (
         source,

--- a/xgcm/test/test_transform.py
+++ b/xgcm/test/test_transform.py
@@ -1066,16 +1066,17 @@ def test_grid_transform_input_check():
 
     # Make sure that a sensible error is raised if xr.Dataset is provided
     # for either one of `source`, `target` or `target_data` input arguments.
-
-    with pytest.raises(ValueError, match=r"should be passed as xr.DataArray"):
+    match_msg = r"needs to be a xr.DataArray. Found"
+    with pytest.raises(ValueError, match=r"`da` " + match_msg):
         transformed = grid.transform(source, axis, target, **transform_kwargs)
-    with pytest.raises(ValueError, match=r"should be passed as xr.DataArray"):
+
+    with pytest.raises(ValueError, match=match_msg):
         transformed = grid.transform(
             source.data, axis, target.to_dataset(name="dummy"), **transform_kwargs
         )
+
     transform_kwargs["target_data"] = transform_kwargs["target_data"].to_dataset(
         name="dummy"
     )
-    with pytest.raises(ValueError, match=r"should be passed as xr.DataArray"):
+    with pytest.raises(ValueError, match=match_msg):
         transformed = grid.transform(source.data, axis, target, **transform_kwargs)
-    

--- a/xgcm/transform.py
+++ b/xgcm/transform.py
@@ -183,11 +183,15 @@ def input_handling(func):
         suffix = kwargs.pop("suffix", "")
 
         # complain if the target values are not provided as xr.dataarray
-        if not isinstance(target_theta_levels, xr.DataArray):
-            raise ValueError("`target_theta_levels` should be passed as xr.DataArray")
+        for var_name, var in [
+            ("phi", phi),
+            ("theta", theta),
+            ("target_theta_levels", target_theta_levels),
+        ]:
+            if not isinstance(var, xr.DataArray):
+                raise ValueError(f"`{var_name}` should be passed as xr.DataArray")
 
         # rename all input dims to unique names to avoid conflicts in xr.apply_ufunc
-
         temp_dim = "temp_dim_target"
         target_theta_levels = target_theta_levels.rename({target_dim: temp_dim})
 

--- a/xgcm/transform.py
+++ b/xgcm/transform.py
@@ -182,15 +182,6 @@ def input_handling(func):
         # pop kwargs used for naming
         suffix = kwargs.pop("suffix", "")
 
-        # complain if the target values are not provided as xr.dataarray
-        for var_name, var in [
-            ("phi", phi),
-            ("theta", theta),
-            ("target_theta_levels", target_theta_levels),
-        ]:
-            if not isinstance(var, xr.DataArray):
-                raise ValueError(f"`{var_name}` should be passed as xr.DataArray")
-
         # rename all input dims to unique names to avoid conflicts in xr.apply_ufunc
         temp_dim = "temp_dim_target"
         target_theta_levels = target_theta_levels.rename({target_dim: temp_dim})


### PR DESCRIPTION
I tried to improve the error handling for the transform routines. The decorator `input_handling` now raises a ValueError if *any* of the data inputs is not a datarray.
The error message is however still not super useful because the variable naming differs for the grid method `grid.transform` and the lower level functions like `linear_interpolation` etc. 

I see a couple of options: 
- Catch the errors in `grid.transform` and raise new errors with proper naming (seems cumbersome).
- Implement the check at the highest level and remove it from the lower level functions (would leave those more error prone, but is anybody actually using these directly?)

cc @andersy005 

 - [x] Closes #328
 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`