### PR TITLE
Implementing axis directionality

### DIFF
--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -118,8 +118,6 @@ class Axis:
               latitude increases with increasing y-index.
             * 'decreasing': coordinate decreases with increasing index, e.g. 
               depth decreases with increasing z-index.
-            Optionally a dict mapping axis name to separate directions for each
-            axis can be passed.
             
 
         REFERENCES

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -74,7 +74,7 @@ class Axis:
         coords=None,
         boundary=None,
         fill_value=None,
-        axis_direction="increasing",
+        direction=None,
     ):
         """
         Create a new Axis object from an input dataset.
@@ -110,8 +110,17 @@ class Axis:
             boundary kwarg when calling specific methods.
         fill_value : {float}, optional
             The value to use in the boundary condition when `boundary='fill'`.
-        axis_direction : str, optional,
-            Directionality of index for axis.
+        direction : str, optional
+            The direction in which axes are defined:
+            * None: Do not define a specific direction; defaults to same
+              behaviour as 'increasing'
+            * 'increasing': coordinate increases with increasing index, e.g. 
+              latitude increases with increasing y-index.
+            * 'decreasing': coordinate decreases with increasing index, e.g. 
+              depth decreases with increasing z-index.
+            Optionally a dict mapping axis name to separate directions for each
+            axis can be passed.
+            
 
         REFERENCES
         ----------
@@ -137,12 +146,12 @@ class Axis:
             # fall back on comodo conventions
             self.coords = comodo.get_axis_positions_and_coords(ds, axis_name)
 
-        if axis_direction=="increasing":
+        if direction=="increasing" or direction is None:
             self.direction_sign=1
-        elif axis_direction=="decreasing":
+        elif direction=="decreasing":
             self.direction_sign=-1
         else:
-            raise ValueError(f"Axis direction not recognized. Expecting `increasing` or `decreasing`, got `{axis_direction}`.")
+            raise ValueError(f"Axis direction not recognized. Expecting `increasing` or `decreasing` or None, got `{direction}`.")
 
         # self.coords is a dictionary with the following structure
         #   key: position_name {'center' ,'left' ,'right', 'outer', 'inner'}
@@ -1067,7 +1076,7 @@ class Grid:
         metrics=None,
         boundary=None,
         fill_value=None,
-        axis_direction=None,
+        direction=None,
     ):
         """
         Create a new Grid object from an input dataset.
@@ -1116,7 +1125,16 @@ class Grid:
             can be passed.
         keep_coords : boolean, optional
             Preserves compatible coordinates. False by default.
-        axis_direction : {str, dict} optional
+        direction : {str, dict} optional
+            The direction in which axes are defined:
+            * None: Do not define a specific direction; defaults to same
+              behaviour as 'increasing'
+            * 'increasing': coordinate increases with increasing index, e.g. 
+              latitude increases with increasing y-index.
+            * 'decreasing': coordinate decreases with increasing index, e.g. 
+              depth decreases with increasing z-index.
+            Optionally a dict mapping axis name to separate directions for each
+            axis can be passed.
 
 
         REFERENCES
@@ -1163,13 +1181,13 @@ class Grid:
                     "mapping axis name to a boundary option; a number or None."
                 )
 
-            if isinstance(axis_direction, dict):
-                axis_axis_direction = axis_direction.get(axis_name, None)
-            elif isinstance(axis_direction, str) or axis_direction is None:
-                axis_axis_direction = axis_direction
+            if isinstance(direction, dict):
+                axis_direction = direction.get(axis_name, None)
+            elif isinstance(direction, str) or direction is None:
+                axis_direction = direction
             else:
                 raise ValueError(
-                    f"axis_direction={axis_direction} is invalid. Please specify a dictionary "
+                    f"direction={direction} is invalid. Please specify a dictionary "
                     "mapping axis name to a direction option; a string or None."
                 )
 
@@ -1181,7 +1199,7 @@ class Grid:
                 coords=coords.get(axis_name),
                 boundary=axis_boundary,
                 fill_value=axis_fillvalue,
-                axis_direction=axis_direction,
+                direction=axis_direction,
             )
 
         if face_connections is not None:

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -782,3 +782,14 @@ def test_boundary_kwarg_same_as_grid_constructor_kwarg():
     actual2 = grid2.interp(ds.data_g, ("X", "Y"))
 
     xr.testing.assert_identical(actual1, actual2)
+
+def test_axisdirectionality():
+    ds = datasets["2d_left"]
+    grid1 = Grid(ds, axis_direction="increasing")
+    grid2 = Grid(ds, axis_direction="decreasing")
+
+    for axis in grid1.axes:
+        diff1 = grid1.diff(ds.data_g, axis)
+        diff2 = grid2.diff(ds.data_g, axis)
+    
+        xr.testing.assert_identical(diff1, -diff2)

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -785,8 +785,8 @@ def test_boundary_kwarg_same_as_grid_constructor_kwarg():
 
 def test_axisdirectionality():
     ds = datasets["2d_left"]
-    grid1 = Grid(ds, axis_direction="increasing")
-    grid2 = Grid(ds, axis_direction="decreasing")
+    grid1 = Grid(ds, direction="increasing")
+    grid2 = Grid(ds, direction="decreasing")
 
     for axis in grid1.axes:
         diff1 = grid1.diff(ds.data_g, axis)


### PR DESCRIPTION
This is a first pass at implementing direction-aware axes (#337), including a preliminary test, with thanks to @jbusecke. The main behavior is to define a sign for the `Grid.diff` function.

There was some discussion in #337 about naming conventions. I have implemented just a simple version here wherein a direction (increasing or decreasing) is specified at the point of defining the grid. Happy to iterate on this logic.  

I was not sure what would be the correct way to define the default behavior. Here I have specified that `None` defaults to assuming that all axes are `increasing`. This leads to some redundancy, but keeps the default conventions consistent with the API for other variables. 

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #337 
 - [x] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
