### PR TITLE
Correction of the Grid.__init__ docstring

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.3.3
+    rev: v0.3.4
     hooks:
       - id: blackdoc
   - repo: https://gitlab.com/pycqa/flake8

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1113,8 +1113,6 @@ class Grid:
             The value to use in boundary conditions with `boundary='fill'`.
             Optionally a dict mapping axis name to seperate values for each axis
             can be passed.
-        keep_coords : boolean, optional
-            Preserves compatible coordinates. False by default.
 
         REFERENCES
         ----------


### PR DESCRIPTION
The keep_coord parameter of the docstring is in fact not a parameter of the `Grid.__init__` method.
I imagine that it is an error of the docstring.