### PR TITLE
Keep coords deprecation warning

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -40,6 +40,13 @@ Internal Changes
   By `Tom Nicholas <https://github.com/TomNicholas>`_.[*]_
 
 
+Deprecations
+~~~~~~~~~~~~~
+
+- The `keep_coords` kwarg is now deprecated, and will be removed in the next version. (:issue:`382`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.[*]_
+
+
 
 v0.5.2 (2021/5/27)
 -------------------

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -991,6 +991,14 @@ class Axis:
         Take the base coords from da, the data from data_new, and return
         a new DataArray with a coordinate on position_to.
         """
+
+        if not keep_coords:
+            warnings.warn(
+                "The keep_coords keyword argument is being deprecated - in future it will be removed "
+                "entirely, and the behaviour will always be that currently given by keep_coords=True.",
+                category=DeprecationWarning,
+            )
+
         position_from, old_dim = self._get_position_name(da)
         try:
             new_dim = self.coords[position_to]

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -771,6 +771,15 @@ def test_keep_coords(funcname, gridtype):
             assert set(result.coords) == set(base_coords + augmented_coords)
 
 
+def test_keep_coords_deprecation():
+    ds, coords, metrics = datasets_grid_metric("B")
+    ds = ds.assign_coords(yt_bis=ds["yt"], xt_bis=ds["xt"])
+    grid = Grid(ds, coords=coords, metrics=metrics)
+    for axis_name in grid.axes.keys():
+        with pytest.warns(DeprecationWarning):
+            grid.diff(ds.tracer, axis_name, keep_coords=False)
+
+
 def test_boundary_kwarg_same_as_grid_constructor_kwarg():
     ds = datasets["2d_left"]
     grid1 = Grid(ds, periodic=False)


### PR DESCRIPTION
 - [x] First part of closing #382
 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
