### PR TITLE
Enabled mypy in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,18 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910-1
+    hooks:
+      - id: mypy
+        # `properies` & `asv_bench` are copied from setup.cfg.
+        # `_typed_ops.py` is added since otherwise mypy will complain (but notably only in pre-commit)
+        exclude: "properties|asv_bench|_typed_ops.py"
+        additional_dependencies: [
+            # Type stubs
+            types-pkg_resources,
+            types-PyYAML,
+            typing-extensions==3.10.0.0,
+            # Dependencies that are typed
+            numpy,
+          ]

--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -6,7 +6,6 @@ channels:
 dependencies:
   - codecov
   - dask
-  - docrep<=0.2.7
   - numpy
   - scipy
   - pip

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -5,7 +5,6 @@ channels:
   - conda-forge
 dependencies:
   - codecov
-  - docrep<=0.2.7
   - numba
   - numpy
   - scipy

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - codecov
   - dask
-  - docrep<=0.2.7
   - numba
   - numpy
   - scipy

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 # -*- coding: utf-8 -*-
 #
 # xgcm documentation build configuration file, created by

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,6 +1,6 @@
 name: test_env_xgcm_docs
 dependencies:
-  - python=3.6
+  - python
   - xarray
   - netcdf4
   - cartopy
@@ -16,7 +16,6 @@ dependencies:
   - sphinx_rtd_theme
   - ipykernel
   - pip:
-    - docrep<=0.2.7
     - nbsphinx
     - jupyter_client
     - sphinx_pangeo_theme

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ install_requires = [
     "dask",
     "numpy",
     "future",
-    "docrep<=0.2.7",
 ]
 doc_requires = [
     "sphinx",

--- a/xgcm/duck_array_ops.py
+++ b/xgcm/duck_array_ops.py
@@ -5,7 +5,7 @@ Shamelessly copied from xarray."""
 import numpy as np
 
 try:
-    import dask.array as dsa
+    import dask.array as dsa  # type: ignore
 
     has_dask = True
 except ImportError:

--- a/xgcm/duck_array_ops.py
+++ b/xgcm/duck_array_ops.py
@@ -26,7 +26,7 @@ def _dask_or_eager_func(name, eager_module=np, list_of_args=False, n_array_args=
 
     else:
 
-        def f(data, *args, **kwargs):
+        def f(data, *args, **kwargs):  # type: ignore
             return getattr(eager_module, name)(data, *args, **kwargs)
 
     return f

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -14,7 +14,7 @@ from .grid_ufunc import GridUFunc, _signatures_equivalent, apply_as_grid_ufunc
 from .metrics import iterate_axis_combinations
 
 try:
-    import numba
+    import numba  # type: ignore
 
     from .transform import conservative_interpolation, linear_interpolation
 except ImportError:

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -5,7 +5,6 @@ import operator
 import warnings
 from collections import OrderedDict
 
-import docrep
 import numpy as np
 import xarray as xr
 
@@ -22,8 +21,6 @@ except ImportError:
     numba = None
 
 from typing import Dict, Optional, Union
-
-docstrings = docrep.DocstringProcessor(doc_key="My doc string")
 
 
 def _maybe_promote_str_to_list(a):
@@ -231,8 +228,6 @@ class Axis:
             summary.append(coord_info)
         return summary
 
-    @docstrings.get_sectionsf("neighbor_binary_func")
-    @docstrings.dedent
     def _neighbor_binary_func(
         self,
         da,
@@ -298,8 +293,6 @@ class Axis:
         da_new = self._wrap_and_replace_coords(da, data_new, to, keep_coords)
 
         return da_new
-
-    docstrings.delete_params("neighbor_binary_func.parameters", "f")
 
     def _neighbor_binary_func_raw(
         self,
@@ -578,7 +571,6 @@ class Axis:
 
         return left, right
 
-    @docstrings.dedent
     def interp(
         self,
         da,
@@ -595,8 +587,26 @@ class Axis:
 
         Parameters
         ----------
-        %(neighbor_binary_func.parameters.no_f)s
+        da : xarray.DataArray
+            The data on which to operate
+        to : {'center', 'left', 'right', 'inner', 'outer'}
+            The direction in which to shift the array. If not specified,
+            default will be used.
+        boundary : {None, 'fill', 'extend'}
+            A flag indicating how to handle boundaries:
 
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+        fill_value : float, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+        vector_partner : dict, optional
+            A single key (string), value (DataArray)
+        keep_coords : boolean, optional
+            Preserves compatible coordinates. False by default.
 
         Returns
         -------
@@ -616,7 +626,6 @@ class Axis:
             keep_coords=keep_coords,
         )
 
-    @docstrings.dedent
     def diff(
         self,
         da,
@@ -632,7 +641,26 @@ class Axis:
 
         Parameters
         ----------
-        %(neighbor_binary_func.parameters.no_f)s
+        da : xarray.DataArray
+            The data on which to operate
+        to : {'center', 'left', 'right', 'inner', 'outer'}
+            The direction in which to shift the array. If not specified,
+            default will be used.
+        boundary : {None, 'fill', 'extend'}
+            A flag indicating how to handle boundaries:
+
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+        fill_value : float, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+        vector_partner : dict, optional
+            A single key (string), value (DataArray)
+        keep_coords : boolean, optional
+            Preserves compatible coordinates. False by default.
 
         Returns
         -------
@@ -651,7 +679,6 @@ class Axis:
             keep_coords=keep_coords,
         )
 
-    @docstrings.dedent
     def cumsum(self, da, to=None, boundary=None, fill_value=0.0, keep_coords=False):
         """
         Cumulatively sum a DataArray, transforming to the intermediate axis
@@ -659,7 +686,24 @@ class Axis:
 
         Parameters
         ----------
-        %(neighbor_binary_func.parameters.no_f)s
+        da : xarray.DataArray
+            The data on which to operate
+        to : {'center', 'left', 'right', 'inner', 'outer'}
+            The direction in which to shift the array. If not specified,
+            default will be used.
+        boundary : {None, 'fill', 'extend'}
+            A flag indicating how to handle boundaries:
+
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+        fill_value : float, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+        keep_coords : boolean, optional
+            Preserves compatible coordinates. False by default.
 
         Returns
         -------
@@ -699,7 +743,6 @@ class Axis:
         da_cum_newcoord = self._wrap_and_replace_coords(da, data, to, keep_coords)
         return da_cum_newcoord
 
-    @docstrings.dedent
     def min(
         self,
         da,
@@ -715,7 +758,26 @@ class Axis:
 
         Parameters
         ----------
-        %(neighbor_binary_func.parameters.no_f)s
+        da : xarray.DataArray
+            The data on which to operate
+        to : {'center', 'left', 'right', 'inner', 'outer'}
+            The direction in which to shift the array. If not specified,
+            default will be used.
+        boundary : {None, 'fill', 'extend'}
+            A flag indicating how to handle boundaries:
+
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+        fill_value : float, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+        vector_partner : dict, optional
+            A single key (string), value (DataArray)
+        keep_coords : boolean, optional
+            Preserves compatible coordinates. False by default.
 
         Returns
         -------
@@ -734,7 +796,6 @@ class Axis:
             keep_coords,
         )
 
-    @docstrings.dedent
     def max(
         self,
         da,
@@ -750,7 +811,26 @@ class Axis:
 
         Parameters
         ----------
-        %(neighbor_binary_func.parameters.no_f)s
+        da : xarray.DataArray
+            The data on which to operate
+        to : {'center', 'left', 'right', 'inner', 'outer'}
+            The direction in which to shift the array. If not specified,
+            default will be used.
+        boundary : {None, 'fill', 'extend'}
+            A flag indicating how to handle boundaries:
+
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+        fill_value : float, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+        vector_partner : dict, optional
+            A single key (string), value (DataArray)
+        keep_coords : boolean, optional
+            Preserves compatible coordinates. False by default.
 
         Returns
         -------
@@ -1463,7 +1543,6 @@ class Grid:
             )
         return metric_vars
 
-    @docstrings.dedent
     def interp_like(self, array, like, boundary=None, fill_value=None):
         """Compares positions between two data arrays and interpolates array to the position of like if necessary
 
@@ -1527,10 +1606,9 @@ class Grid:
             summary += axis._coord_desc()
         return "\n".join(summary)
 
-    @docstrings.get_sectionsf("grid_func", sections=["Parameters", "Examples"])
-    @docstrings.dedent
     def _grid_func(self, funcname, da, axis, **kwargs):
-        """this function calls appropriate functions from `Axis` objects.
+        """
+        This function calls appropriate functions from `Axis` objects.
         It handles multiple axis input and weighting with metrics
 
         Parameters
@@ -1562,12 +1640,10 @@ class Grid:
             A single key (string), value (DataArray).
             Optionally a dict with seperate values for each axis can be passed (see example)
         metric_weighted : str or tuple of str or dict, optional
-            If an axis or list of axes is specified,
-            the appropriate grid metrics will be used to determined the weight for interpolation.
+            Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
             E.g. if passing `metric_weighted=['X', 'Y']`, values will be weighted by horizontal area.
             If `False` (default), the points will be weighted equally.
-            Optionally a dict with seperate values for each axis can be passed (see example)
-
+            Optionally a dict with seperate values for each axis can be passed.
         """
 
         if (not isinstance(axis, list)) and (not isinstance(axis, tuple)):
@@ -1903,7 +1979,6 @@ class Grid:
             **kwargs,
         )
 
-    @docstrings.dedent
     def interp(self, da, axis, **kwargs):
         """
         Interpolate neighboring points to the intermediate grid point along
@@ -1912,11 +1987,36 @@ class Grid:
 
         Parameters
         ----------
-        %(grid_func.parameters)s
+        axis : str or list or tuple
+            Name of the axis on which to act. Multiple axes can be passed as list or
+            tuple (e.g. ``['X', 'Y']``). Functions will be executed over each axis in the
+            given order.
+        to : str or dict, optional
+            The direction in which to shift the array (can be ['center','left','right','inner','outer']).
+            If not specified, default will be used.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        boundary : None or str or dict, optional
+            A flag indicating how to handle boundaries:
 
-        Examples
-        --------
-        %(grid_func.examples)s
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+
+            Optionally a dict with separate values for each axis can be passed (see example)
+        fill_value : {float, dict}, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        vector_partner : dict, optional
+            A single key (string), value (DataArray).
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        metric_weighted : str or tuple of str or dict, optional
+            Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
+            E.g. if passing `metric_weighted=['X', 'Y']`, values will be weighted by horizontal area.
+            If `False` (default), the points will be weighted equally.
+            Optionally a dict with seperate values for each axis can be passed.
 
         Returns
         -------
@@ -1933,18 +2033,42 @@ class Grid:
         """
         return self._1d_grid_ufunc_dispatch("interp", da, axis, **kwargs)
 
-    @docstrings.dedent
     def diff(self, da, axis, **kwargs):
         """
         Difference neighboring points to the intermediate grid point.
 
         Parameters
         ----------
-        %(grid_func.parameters)s
+        axis : str or list or tuple
+            Name of the axis on which to act. Multiple axes can be passed as list or
+            tuple (e.g. ``['X', 'Y']``). Functions will be executed over each axis in the
+            given order.
+        to : str or dict, optional
+            The direction in which to shift the array (can be ['center','left','right','inner','outer']).
+            If not specified, default will be used.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        boundary : None or str or dict, optional
+            A flag indicating how to handle boundaries:
 
-        Examples
-        --------
-        %(grid_func.examples)s
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+
+            Optionally a dict with separate values for each axis can be passed (see example)
+        fill_value : {float, dict}, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        vector_partner : dict, optional
+            A single key (string), value (DataArray).
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        metric_weighted : str or tuple of str or dict, optional
+            Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
+            E.g. if passing `metric_weighted=['X', 'Y']`, values will be weighted by horizontal area.
+            If `False` (default), the points will be weighted equally.
+            Optionally a dict with seperate values for each axis can be passed.
 
         Returns
         -------
@@ -1961,18 +2085,42 @@ class Grid:
         """
         return self._1d_grid_ufunc_dispatch("diff", da, axis, **kwargs)
 
-    @docstrings.dedent
     def min(self, da, axis, **kwargs):
         """
         Minimum of neighboring points on the intermediate grid point.
 
-        Parameters
+                Parameters
         ----------
-        %(grid_func.parameters)s
+        axis : str or list or tuple
+            Name of the axis on which to act. Multiple axes can be passed as list or
+            tuple (e.g. ``['X', 'Y']``). Functions will be executed over each axis in the
+            given order.
+        to : str or dict, optional
+            The direction in which to shift the array (can be ['center','left','right','inner','outer']).
+            If not specified, default will be used.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        boundary : None or str or dict, optional
+            A flag indicating how to handle boundaries:
 
-        Examples
-        --------
-        %(grid_func.examples)s
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+
+            Optionally a dict with separate values for each axis can be passed (see example)
+        fill_value : {float, dict}, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        vector_partner : dict, optional
+            A single key (string), value (DataArray).
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        metric_weighted : str or tuple of str or dict, optional
+            Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
+            E.g. if passing `metric_weighted=['X', 'Y']`, values will be weighted by horizontal area.
+            If `False` (default), the points will be weighted equally.
+            Optionally a dict with seperate values for each axis can be passed.
 
         Returns
         -------
@@ -1990,18 +2138,42 @@ class Grid:
         """
         return self._1d_grid_ufunc_dispatch("min", da, axis, **kwargs)
 
-    @docstrings.dedent
     def max(self, da, axis, **kwargs):
         """
         Maximum of neighboring points on the intermediate grid point.
 
         Parameters
         ----------
-        %(grid_func.parameters)s
+        axis : str or list or tuple
+            Name of the axis on which to act. Multiple axes can be passed as list or
+            tuple (e.g. ``['X', 'Y']``). Functions will be executed over each axis in the
+            given order.
+        to : str or dict, optional
+            The direction in which to shift the array (can be ['center','left','right','inner','outer']).
+            If not specified, default will be used.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        boundary : None or str or dict, optional
+            A flag indicating how to handle boundaries:
 
-        Examples
-        --------
-        %(grid_func.examples)s
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+
+            Optionally a dict with separate values for each axis can be passed (see example)
+        fill_value : {float, dict}, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        vector_partner : dict, optional
+            A single key (string), value (DataArray).
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        metric_weighted : str or tuple of str or dict, optional
+            Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
+            E.g. if passing `metric_weighted=['X', 'Y']`, values will be weighted by horizontal area.
+            If `False` (default), the points will be weighted equally.
+            Optionally a dict with seperate values for each axis can be passed.
 
         Returns
         -------
@@ -2019,7 +2191,6 @@ class Grid:
         """
         return self._1d_grid_ufunc_dispatch("max", da, axis, **kwargs)
 
-    @docstrings.dedent
     def cumsum(self, da, axis, **kwargs):
         """
         Cumulatively sum a DataArray, transforming to the intermediate axis
@@ -2027,11 +2198,33 @@ class Grid:
 
         Parameters
         ----------
-        %(grid_func.parameters)s
+        axis : str or list or tuple
+            Name of the axis on which to act. Multiple axes can be passed as list or
+            tuple (e.g. ``['X', 'Y']``). Functions will be executed over each axis in the
+            given order.
+        to : str or dict, optional
+            The direction in which to shift the array (can be ['center','left','right','inner','outer']).
+            If not specified, default will be used.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        boundary : None or str or dict, optional
+            A flag indicating how to handle boundaries:
 
-        Examples
-        --------
-        %(grid_func.examples)s
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+
+            Optionally a dict with separate values for each axis can be passed (see example)
+        fill_value : {float, dict}, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        metric_weighted : str or tuple of str or dict, optional
+            Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
+            E.g. if passing `metric_weighted=['X', 'Y']`, values will be weighted by horizontal area.
+            If `False` (default), the points will be weighted equally.
+            Optionally a dict with seperate values for each axis can be passed.
 
         Returns
         -------
@@ -2049,7 +2242,6 @@ class Grid:
         """
         return self._grid_func("cumsum", da, axis, **kwargs)
 
-    @docstrings.dedent
     def _apply_vector_function(self, function, vector, **kwargs):
         # the keys, should be axis names
         assert len(vector) == 2
@@ -2094,7 +2286,6 @@ class Grid:
 
         return {x_axis_name: x_component, y_axis_name: y_component}
 
-    @docstrings.dedent
     def interp_2d_vector(self, vector, **kwargs):
         """
         Interpolate a 2D vector to the intermediate grid point. This method is
@@ -2105,8 +2296,24 @@ class Grid:
         vector : dict
             A dictionary with two entries. Keys are axis names, values are
             vector components along each axis.
+        to : {'center', 'left', 'right', 'inner', 'outer'}
+            The direction in which to shift the array. If not specified,
+            default will be used.
+        boundary : {None, 'fill', 'extend'}
+            A flag indicating how to handle boundaries:
 
-        %(neighbor_binary_func.parameters.no_f)s
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+        fill_value : float, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+        vector_partner : dict, optional
+            A single key (string), value (DataArray)
+        keep_coords : boolean, optional
+            Preserves compatible coordinates. False by default.
 
         Returns
         -------
@@ -2117,16 +2324,42 @@ class Grid:
 
         return self._apply_vector_function(Axis.interp, vector, **kwargs)
 
-    @docstrings.dedent
     def derivative(self, da, axis, **kwargs):
         """
         Take the centered-difference derivative along specified axis.
 
         Parameters
         ----------
-        axis : str
-            Name of the axis on which to act
-        %(grid_func.parameters)s
+        axis : str or list or tuple
+            Name of the axis on which to act. Multiple axes can be passed as list or
+            tuple (e.g. ``['X', 'Y']``). Functions will be executed over each axis in the
+            given order.
+        to : str or dict, optional
+            The direction in which to shift the array (can be ['center','left','right','inner','outer']).
+            If not specified, default will be used.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        boundary : None or str or dict, optional
+            A flag indicating how to handle boundaries:
+
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+
+            Optionally a dict with separate values for each axis can be passed (see example)
+        fill_value : {float, dict}, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        vector_partner : dict, optional
+            A single key (string), value (DataArray).
+            Optionally a dict with seperate values for each axis can be passed (see example)
+        metric_weighted : str or tuple of str or dict, optional
+            Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
+            E.g. if passing `metric_weighted=['X', 'Y']`, values will be weighted by horizontal area.
+            If `False` (default), the points will be weighted equally.
+            Optionally a dict with seperate values for each axis can be passed.
 
         Returns
         -------
@@ -2139,7 +2372,6 @@ class Grid:
         dx = self.get_metric(diff, (axis,))
         return diff / dx
 
-    @docstrings.dedent
     def integrate(self, da, axis, **kwargs):
         """
         Perform finite volume integration along specified axis or axes,
@@ -2167,7 +2399,6 @@ class Grid:
 
         return weighted.sum(dim, **kwargs)
 
-    @docstrings.dedent
     def cumint(self, da, axis, **kwargs):
         """
         Perform cumulative integral along specified axis or axes,
@@ -2175,9 +2406,33 @@ class Grid:
 
         Parameters
         ----------
-        axis : str, list of str
-            Name of the axis on which to act
-        %(grid_func.parameters)s
+        axis : str or list or tuple
+            Name of the axis on which to act. Multiple axes can be passed as list or
+            tuple (e.g. ``['X', 'Y']``). Functions will be executed over each axis in the
+            given order.
+        to : str or dict, optional
+            The direction in which to shift the array (can be ['center','left','right','inner','outer']).
+            If not specified, default will be used.
+            Optionally a dict with separate values for each axis can be passed (see example)
+        boundary : None or str or dict, optional
+            A flag indicating how to handle boundaries:
+
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+
+            Optionally a dict with separate values for each axis can be passed.
+        fill_value : {float, dict}, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+            Optionally a dict with separate values for each axis can be passed.
+        metric_weighted : str or tuple of str or dict, optional
+            Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
+            E.g. if passing `metric_weighted=['X', 'Y']`, values will be weighted by horizontal area.
+            If `False` (default), the points will be weighted equally.
+            Optionally a dict with seperate values for each axis can be passed.
 
         Returns
         -------
@@ -2191,7 +2446,6 @@ class Grid:
 
         return self.cumsum(weighted, axis, **kwargs)
 
-    @docstrings.dedent
     def average(self, da, axis, **kwargs):
         """
         Perform weighted mean reduction along specified axis or axes,
@@ -2299,7 +2553,6 @@ class Grid:
         ax = self.axes[axis]
         return ax.transform(da, target, **kwargs)
 
-    @docstrings.dedent
     def diff_2d_vector(self, vector, **kwargs):
         """
         Difference a 2D vector to the intermediate grid point. This method is
@@ -2310,9 +2563,24 @@ class Grid:
         vector : dict
             A dictionary with two entries. Keys are axis names, values are
             vector components along each axis.
+        to : {'center', 'left', 'right', 'inner', 'outer'}
+            The direction in which to shift the array. If not specified,
+            default will be used.
+        boundary : {None, 'fill', 'extend'}
+            A flag indicating how to handle boundaries:
 
-        %(neighbor_binary_func.parameters.no_f)s
-
+            * None:  Do not apply any boundary conditions. Raise an error if
+              boundary conditions are required for the operation.
+            * 'fill':  Set values outside the array boundary to fill_value
+              (i.e. a Dirichlet boundary condition.)
+            * 'extend': Set values outside the array to the nearest array
+              value. (i.e. a limited form of Neumann boundary condition.)
+        fill_value : float, optional
+            The value to use in the boundary condition with `boundary='fill'`.
+        vector_partner : dict, optional
+            A single key (string), value (DataArray)
+        keep_coords : boolean, optional
+            Preserves compatible coordinates. False by default.
         Returns
         -------
         vector_diff : dict

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     numba = None
 
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Iterable, List, Union
 
 
 def _maybe_promote_str_to_list(a):
@@ -1305,9 +1305,9 @@ class Grid:
 
     def _as_axis_kwarg_mapping(
         self,
-        kwargs: Union[str, float, int, Dict[str, Union[str, float, int]]],
-        axes: Optional[list] = None,
-    ) -> Dict[str, Union[str, float, int]]:
+        kwargs: Union[Any, Dict[str, Any]],
+        axes: List[str] = None,
+    ) -> Dict[str, Any]:
         """Convert kwarg input into dict for each available axis
         E.g. for a grid with 2 axes for the keyword argument `periodic`
         periodic = True --> periodic = {'X': True, 'Y':True}
@@ -1317,7 +1317,7 @@ class Grid:
         if axes is None:
             axes = self.axes
 
-        parsed_kwargs = dict()
+        parsed_kwargs: Dict[str, Any] = dict()
         if isinstance(kwargs, dict):
             parsed_kwargs = kwargs
         else:
@@ -1763,8 +1763,8 @@ class Grid:
         to=None,
         keep_coords=False,
         metric_weighted: Union[
-            str, list, tuple, Dict[str, Union[str, list, tuple]]
-        ] = False,
+            str, Iterable[str], Dict[str, Union[str, Iterable[str]]]
+        ] = None,
         **kwargs,
     ):
         """
@@ -1785,7 +1785,7 @@ class Grid:
         if isinstance(axis, str):
             axis = [axis]
 
-        # convert inpug arguments into axes-kwarg mappings
+        # convert input arguments into axes-kwarg mappings
         to = self._as_axis_kwarg_mapping(to)
 
         if isinstance(metric_weighted, str):

--- a/xgcm/test/test_duck_array_ops.py
+++ b/xgcm/test/test_duck_array_ops.py
@@ -1,4 +1,4 @@
-import dask as dsk
+import dask as dsk  # type: ignore
 import numpy as np
 
 from xgcm.duck_array_ops import concatenate

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -1,6 +1,6 @@
 import re
 
-import dask.array
+import dask.array  # type: ignore
 import numpy as np
 import pytest
 import xarray as xr

--- a/xgcm/test/test_transform.py
+++ b/xgcm/test/test_transform.py
@@ -8,7 +8,7 @@ high level: API implementations in the grid object (located in grid.py)
 # TODO:
 # - performance test? It would be nice to have these right after so we can track the performance as this feature evolves
 
-import dask
+import dask  # type: ignore
 import numpy as np
 import pytest
 import xarray as xr
@@ -16,7 +16,7 @@ import xarray as xr
 from xgcm.grid import Grid
 
 try:
-    import numba
+    import numba  # type: ignore
 
     from ..transform import (
         conservative_interpolation,
@@ -944,7 +944,7 @@ def processes_client():
 
 @pytest.fixture(scope="module")
 def distributed_client():
-    from dask.distributed import Client, LocalCluster
+    from dask.distributed import Client, LocalCluster  # type: ignore
 
     cluster = LocalCluster(threads_per_worker=1, n_workers=2, processes=True)
     client = Client(cluster)

--- a/xgcm/transform.py
+++ b/xgcm/transform.py
@@ -5,7 +5,7 @@ import functools
 
 import numpy as np
 import xarray as xr
-from numba import boolean, float32, float64, guvectorize
+from numba import boolean, float32, float64, guvectorize  # type: ignore
 
 """Low level functions (numba/numpy)"""
 


### PR DESCRIPTION
@rabernat I think you merged #386 a bit pre-emptively - I've been running mypy just on `grid_ufunc.py`, and when I run on the whole code on the `master` branch I get a couple of typing errors that I don't understand:

```
xgcm/duck_array_ops.py:29: error: All conditional function variants must have identical signatures
doc/conf.py:244: error: Need type annotation for "latex_elements" (hint: "latex_elements: Dict[<type>, <type>] = ...")
Found 2 errors in 2 files (checked 19 source files)
```

I copied the actual pre-commit config from xarray, removing some datetime stubs that seemed irrelevant.

 - [x] Passes `pre-commit run --all-files`
