### PR TITLE
Deprecation warnings

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -21,6 +21,8 @@ Documentation
 
 Internal Changes
 ~~~~~~~~~~~~~
+- Add deprecation warnings for future changes in the API (:issue:`409`,:pull:`411`).
+  By `Julius Busecke <https://github.com/jbusecke>`_.
 
 
 v0.6.0 (2021/11/03)

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1210,6 +1210,16 @@ class Grid:
         self._ds = ds
         self._check_dims = check_dims
 
+        # Deprecation Warnigns
+        if boundary:
+            warnings.warn(
+                "The `boundary` argument will be renamed "
+                "to `padding` to better reflect the process "
+                "of array padding and avoid confusion with "
+                "physical boundary conditions (e.g. ocean land boundary).",
+                category=DeprecationWarning,
+            )
+
         if coords:
             all_axes = coords.keys()
         else:

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1235,6 +1235,25 @@ class Grid:
                 category=DeprecationWarning,
             )
 
+        if fill_value:
+            warnings.warn(
+                "The default fill_value will be changed to nan (from 0.0 previously) "
+                "in future versions. Provide `fill_value=0.0` to preserve previous behavior.",
+                category=DeprecationWarning,
+            )
+
+        extrapolate_warning = False
+        if boundary == "extrapolate":
+            extrapolate_warning = True
+        if isinstance(boundary, dict):
+            if any([k == "extrapolate" for k in boundary.keys()]):
+                extrapolate_warning = True
+        if extrapolate_warning:
+            warnings.warn(
+                "The `boundary='extrapolate'` option will no longer be supported in future releases.",
+                category=DeprecationWarning,
+            )
+
         if coords:
             all_axes = coords.keys()
         else:
@@ -1932,6 +1951,12 @@ class Grid:
     def _apply_vector_function(self, function, vector, **kwargs):
         # the keys, should be axis names
         assert len(vector) == 2
+
+        warnings.warn(
+            "`interp_2d_vector` and `diff_2d_vector` will be removed from future releases."
+            "The same functionality will be available under the `xgcm.Grid` methods.",
+            category=DeprecationWarning,
+        )
 
         # this is currently only tested for c-grid vectors defined on edges
         # moving to cell centers. We need to detect if we got something else

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1211,6 +1211,13 @@ class Grid:
         self._check_dims = check_dims
 
         # Deprecation Warnigns
+        warnings.warn(
+            "The `xgcm.Axis` class will be deprecated in the future. "
+            "Please make sure to use the `xgcm.Grid` methods for your work instead.",
+            category=DeprecationWarning,
+        )
+        # This will show up every time, but I think that is fine
+
         if boundary:
             warnings.warn(
                 "The `boundary` argument will be renamed "

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1220,6 +1220,14 @@ class Grid:
                 category=DeprecationWarning,
             )
 
+        # Deprecation Warnigns
+        if periodic:
+            warnings.warn(
+                "The `periodic` argument will be deprecated. "
+                "To preserve previous behavior supply `boundary = 'periodic'.",
+                category=DeprecationWarning,
+            )
+
         if coords:
             all_axes = coords.keys()
         else:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #409 
 - [x] Passes `pre-commit run --all-files`


- [x] Rename boundary padding kwarg
- [x] `periodic` kwarg is being dropped
- [x] `Axis` is going to go entirely in favour of always using grid
- [x] `fill_value` default being changed from zero to NaN
- [x] extrapolate functionality might get dropped
- [x] (at some point) change `interp_2d_vector` API to be more intuitive
