### PR TITLE
Test suite without dask

### DIFF
--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -5,7 +5,6 @@ channels:
   - conda-forge
 dependencies:
   - codecov
-  - dask
   - docrep<=0.2.7
   - numpy
   - scipy


### PR DESCRIPTION
Removes dask from the "core dependencies" CI environment file, so that no we have a CI run that tests everything without dask installed.

I altered an existing run rather than added a new run because this seemed to better fit the intention of "just core dependencies".

I don't expect this to pass - but we can push to this branch to start fixing any bugs that this reveals.

 - [x] Part of closing #419 
