### PR TITLE
Fix formatting issue with grid.rst

### DIFF
--- a/doc/grids.rst
+++ b/doc/grids.rst
@@ -329,7 +329,7 @@ For example:
 .. ipython:: python
 
     f2 = f + xr.Dataset(coords={"y": np.arange(1, 3)})["y"]
-    f2 = f2.assign_coords(h=f2.y ** 2)
+    f2 = f2.assign_coords(h=f2.y**2)
     print(f2)
     grid.interp(f2, "X", keep_coords=True)
 


### PR DESCRIPTION
The builds in #425 and #426 are blocked by a seemingly harmless but weird failure. I do not understand how this came about, but if this little change in formatting fixes it, ill just merge and not think about it twice.
