### PR TITLE
Enable dask in gridops

### DIFF
--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1798,10 +1798,14 @@ class Grid:
             else:
                 map_overlap = False
 
+            print("grid_ufunc call here:")
+            print(grid_ufunc.signature)
+            print(ax_name)
+
             array = grid_ufunc(
                 self,
                 array,
-                axis=[ax_name],
+                axis=[(ax_name,)],
                 keep_coords=keep_coords,
                 dask=dask,
                 map_overlap=map_overlap,

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1788,19 +1788,12 @@ class Grid:
                 array = array * metric
 
             # if chunked along core dim then we need map_overlap
-            print(type(array.data))
             core_dim = self._get_dims_from_axis(da, ax_name)
-            print(core_dim)
-            print(remaining_kwargs)
             if _has_chunked_core_dims(array, core_dim):
                 map_overlap = True
                 dask = "allowed"
             else:
                 map_overlap = False
-
-            print("grid_ufunc call here:")
-            print(grid_ufunc.signature)
-            print(ax_name)
 
             array = grid_ufunc(
                 self,

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -8,10 +8,16 @@ from collections import OrderedDict
 import docrep  # type: ignore
 import numpy as np
 import xarray as xr
+from dask.array import Array as Dask_Array
 
 from . import comodo, gridops
 from .duck_array_ops import _apply_boundary_condition, _pad_array, concatenate
-from .grid_ufunc import GridUFunc, _signatures_equivalent, apply_as_grid_ufunc
+from .grid_ufunc import (
+    GridUFunc,
+    _has_chunked_core_dims,
+    _signatures_equivalent,
+    apply_as_grid_ufunc,
+)
 from .metrics import iterate_axis_combinations
 
 try:
@@ -1760,6 +1766,12 @@ class Grid:
 
         signatures = self._create_1d_grid_ufunc_signatures(da, axis=axis, to=to)
 
+        # if any dims are chunked then we need dask
+        if isinstance(da.data, Dask_Array):
+            dask = "parallelized"
+        else:
+            dask = "forbidden"
+
         array = da
         # Apply 1D function over multiple axes
         # TODO This will call xarray.apply_ufunc once for each axis, but if signatures + kwargs are the same then we
@@ -1775,8 +1787,25 @@ class Grid:
                 metric = self.get_metric(array, ax_metric_weighted)
                 array = array * metric
 
+            # if chunked along core dim then we need map_overlap
+            print(type(array.data))
+            core_dim = self._get_dims_from_axis(da, ax_name)
+            print(core_dim)
+            print(remaining_kwargs)
+            if _has_chunked_core_dims(array, core_dim):
+                map_overlap = True
+                dask = "allowed"
+            else:
+                map_overlap = False
+
             array = grid_ufunc(
-                self, array, axis=[ax_name], keep_coords=keep_coords, **remaining_kwargs
+                self,
+                array,
+                axis=[ax_name],
+                keep_coords=keep_coords,
+                dask=dask,
+                map_overlap=map_overlap,
+                **remaining_kwargs,
             )
 
             if ax_metric_weighted:

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -335,7 +335,7 @@ def apply_as_grid_ufunc(
 
     print(args[0].chunksizes)
     print(axis)
-    print(signature)
+    print(f"signature={signature}")
     print(boundary_width)
     print(boundary)
     print(dask)
@@ -359,6 +359,9 @@ def apply_as_grid_ufunc(
         in_ax_pos,
         out_ax_pos,
     ) = _parse_grid_ufunc_signature(signature)
+
+    print(axis)
+    print(in_dummy_ax_names)
 
     dummy_to_real_axes_mapping = _identify_dummy_axes_with_real_axes(
         in_dummy_ax_names, axis
@@ -469,6 +472,9 @@ def apply_as_grid_ufunc(
         # dask.map_overlap needs chunks in terms of axis number, not axis name (i.e. (chunks, ...), not {str: chunks})
         true_chunksizes_per_numpy_axis = _dict_to_numbered_axes(true_chunksizes)
 
+        print(boundary_width_per_numpy_axis)
+        print(true_chunksizes_per_numpy_axis)
+
         # (we don't need a separate code path using bare map_blocks if boundary_widths are zero because map_overlap just
         # calls map_blocks automatically in that scenario)
         def mapped_func(*a, **kw):
@@ -492,6 +498,8 @@ def apply_as_grid_ufunc(
     out_sizes = {
         out_dim: grid._ds.dims[out_dim] for arg in out_core_dims for out_dim in arg
     }
+
+    print(rechunked_padded_args[0].chunksizes)
 
     # Perform operation via xarray.apply_ufunc
     results = xr.apply_ufunc(
@@ -668,6 +676,8 @@ def _identify_dummy_axes_with_real_axes(
             "Number of entries in `axis` does not match the number of variables in the input signature"
         )
     for i, (arg_axes, dummy_arg_axes) in enumerate(zip(axis, sig_in_dummy_ax_names)):
+        print(arg_axes)
+        print(dummy_arg_axes)
         if len(arg_axes) != len(dummy_arg_axes):
             raise ValueError(
                 f"Number of Axes in `axis` entry number {i} does not match the number of Axes in that entry in the input signature"

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -333,6 +333,14 @@ def apply_as_grid_ufunc(
     xarray.apply_ufunc
     """
 
+    print(args[0].chunksizes)
+    print(axis)
+    print(signature)
+    print(boundary_width)
+    print(boundary)
+    print(dask)
+    print(map_overlap)
+
     if grid is None:
         raise ValueError("Must provide a grid object to describe the Axes")
 
@@ -464,6 +472,7 @@ def apply_as_grid_ufunc(
         # (we don't need a separate code path using bare map_blocks if boundary_widths are zero because map_overlap just
         # calls map_blocks automatically in that scenario)
         def mapped_func(*a, **kw):
+            # print(type(a[0]))
             return dask_map_overlap(
                 func,
                 *a,
@@ -544,11 +553,12 @@ def apply_as_grid_ufunc(
     return results_with_coords
 
 
-def _has_chunked_core_dims(obj: xr.DataArray, core_dims: Sequence[str]) -> bool:
-    def is_dim_chunked(a, dim):
-        # TODO this func can't handle Datasets - it will error if you check multiple variables with different chunking
-        return len(a.variable.chunksizes[dim]) > 1
+def is_dim_chunked(a, dim):
+    # TODO this func can't handle Datasets - it will error if you check multiple variables with different chunking
+    return len(a.variable.chunksizes[dim]) > 1
 
+
+def _has_chunked_core_dims(obj: xr.DataArray, core_dims: Sequence[str]) -> bool:
     # TODO what if only some of the core dimensions are chunked?
     return obj.chunks is not None and any(is_dim_chunked(obj, dim) for dim in core_dims)
 

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -333,14 +333,6 @@ def apply_as_grid_ufunc(
     xarray.apply_ufunc
     """
 
-    print(args[0].chunksizes)
-    print(axis)
-    print(f"signature={signature}")
-    print(boundary_width)
-    print(boundary)
-    print(dask)
-    print(map_overlap)
-
     if grid is None:
         raise ValueError("Must provide a grid object to describe the Axes")
 
@@ -359,9 +351,6 @@ def apply_as_grid_ufunc(
         in_ax_pos,
         out_ax_pos,
     ) = _parse_grid_ufunc_signature(signature)
-
-    print(axis)
-    print(in_dummy_ax_names)
 
     dummy_to_real_axes_mapping = _identify_dummy_axes_with_real_axes(
         in_dummy_ax_names, axis
@@ -472,13 +461,9 @@ def apply_as_grid_ufunc(
         # dask.map_overlap needs chunks in terms of axis number, not axis name (i.e. (chunks, ...), not {str: chunks})
         true_chunksizes_per_numpy_axis = _dict_to_numbered_axes(true_chunksizes)
 
-        print(boundary_width_per_numpy_axis)
-        print(true_chunksizes_per_numpy_axis)
-
         # (we don't need a separate code path using bare map_blocks if boundary_widths are zero because map_overlap just
         # calls map_blocks automatically in that scenario)
         def mapped_func(*a, **kw):
-            # print(type(a[0]))
             return dask_map_overlap(
                 func,
                 *a,
@@ -498,8 +483,6 @@ def apply_as_grid_ufunc(
     out_sizes = {
         out_dim: grid._ds.dims[out_dim] for arg in out_core_dims for out_dim in arg
     }
-
-    print(rechunked_padded_args[0].chunksizes)
 
     # Perform operation via xarray.apply_ufunc
     results = xr.apply_ufunc(
@@ -676,8 +659,6 @@ def _identify_dummy_axes_with_real_axes(
             "Number of entries in `axis` does not match the number of variables in the input signature"
         )
     for i, (arg_axes, dummy_arg_axes) in enumerate(zip(axis, sig_in_dummy_ax_names)):
-        print(arg_axes)
-        print(dummy_arg_axes)
         if len(arg_axes) != len(dummy_arg_axes):
             raise ValueError(
                 f"Number of Axes in `axis` entry number {i} does not match the number of Axes in that entry in the input signature"

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -701,6 +701,32 @@ def test_multi_axis_input(all_datasets, func, periodic, boundary):
         xr.testing.assert_allclose(serial, full)
 
 
+@pytest.mark.skip
+@pytest.mark.parametrize("func", ["interp", "max", "min", "diff", "cumsum"])
+@pytest.mark.parametrize("periodic", ["True", "False", ["X"], ["Y"], ["X", "Y"]])
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "fill",
+        # "extrapolate", # do we not support extrapolation anymore?
+        "extend",
+        {"X": "fill", "Y": "extend"},
+        {"X": "extend", "Y": "fill"},
+    ],
+)
+def test_dask_vs_eager(all_datasets, func, periodic, boundary):
+    ds, coords, metrics = datasets_grid_metric("C")
+    grid = Grid(ds, coords=coords)
+
+    eager_result = grid.diff(ds.tracer, "X")
+
+    ds = ds.chunk({"xt": 1, "yt": 1, "time": 1, "zt": 1})
+    grid = Grid(ds, coords=coords)
+    dask_result = grid.diff(ds.tracer, "X").compute()
+
+    xr.testing.assert_identical(dask_result, eager_result)
+
+
 def test_grid_dict_input_boundary_fill(nonperiodic_1d):
     """Test axis kwarg input functionality using dict input"""
     ds, _, _ = nonperiodic_1d

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -717,13 +717,20 @@ def test_dask_vs_eager(all_datasets, func, periodic, boundary):
     ds, coords, metrics = datasets_grid_metric("C")
     grid = Grid(ds, coords=coords)
 
+    print(grid)
+    print(ds.coords)
+
     eager_result = grid.diff(ds.tracer, "X")
 
-    ds = ds.chunk({"xt": 1, "yt": 1, "time": 1, "zt": 1})
+    print(eager_result)
+
+    ds = ds.chunk({"xt": 3, "yt": 1, "time": 1, "zt": 1})
     grid = Grid(ds, coords=coords)
     dask_result = grid.diff(ds.tracer, "X").compute()
 
     xr.testing.assert_identical(dask_result, eager_result)
+
+    # assert False
 
 
 def test_grid_dict_input_boundary_fill(nonperiodic_1d):

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -701,38 +701,6 @@ def test_multi_axis_input(all_datasets, func, periodic, boundary):
         xr.testing.assert_allclose(serial, full)
 
 
-@pytest.mark.parametrize("func", ["interp", "max", "min", "diff", "cumsum"])
-@pytest.mark.parametrize("periodic", ["True", "False", ["X"], ["Y"], ["X", "Y"]])
-@pytest.mark.parametrize(
-    "boundary",
-    [
-        "fill",
-        # "extrapolate", # do we not support extrapolation anymore?
-        "extend",
-        {"X": "fill", "Y": "extend"},
-        {"X": "extend", "Y": "fill"},
-    ],
-)
-def test_dask_vs_eager(all_datasets, func, periodic, boundary):
-    ds, coords, metrics = datasets_grid_metric("C")
-    grid = Grid(ds, coords=coords)
-
-    print(grid)
-    print(ds.coords)
-
-    eager_result = grid.diff(ds.tracer, "X")
-
-    print(eager_result)
-
-    ds = ds.chunk({"xt": 3, "yt": 1, "time": 1, "zt": 1})
-    grid = Grid(ds, coords=coords)
-    dask_result = grid.diff(ds.tracer, "X").compute()
-
-    xr.testing.assert_identical(dask_result, eager_result)
-
-    # assert False
-
-
 def test_grid_dict_input_boundary_fill(nonperiodic_1d):
     """Test axis kwarg input functionality using dict input"""
     ds, _, _ = nonperiodic_1d

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -701,7 +701,6 @@ def test_multi_axis_input(all_datasets, func, periodic, boundary):
         xr.testing.assert_allclose(serial, full)
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("func", ["interp", "max", "min", "diff", "cumsum"])
 @pytest.mark.parametrize("periodic", ["True", "False", ["X"], ["Y"], ["X", "Y"]])
 @pytest.mark.parametrize(

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -542,7 +542,6 @@ class TestDaskOverlap:
             grid=grid,
             signature="(X:center)->(X:left)",
             boundary_width={"X": (1, 0)},
-            # boundary="",
             dask="allowed",
             map_overlap=True,
         ).compute()
@@ -575,46 +574,6 @@ class TestDaskOverlap:
             da,
             axis=[("depth",)],
         ).compute()
-        assert_equal(result, expected)
-
-    def test_chunked_core_dims_unchanging_chunksize_center_to_right(self):
-        # attempt to debug GH #438
-
-        def diff_center_to_right(a):
-            return a[..., 1:] - a[..., :-1]
-
-        grid = create_1d_test_grid("depth")
-        da = np.sin(grid._ds.depth_c * 2 * np.pi / 9).chunk(1)
-        da.coords["depth_c"] = grid._ds.depth_c
-
-        diffed = (da.roll(depth_c=-1, roll_coords=False) - da).data
-        expected = xr.DataArray(
-            diffed, dims=["depth_r"], coords={"depth_r": grid._ds.depth_r}
-        ).compute()
-
-        result = grid.diff(da, axis="depth", to="right").compute()
-        assert_equal(result, expected)
-
-    def test_chunked_core_dims_unchanging_chunksize_center_to_right_2d(self):
-        # attempt to debug GH #438
-
-        def diff_center_to_right(a):
-            return a[..., 1:] - a[..., :-1]
-
-        grid = create_2d_test_grid("depth", "y")
-
-        da = (grid._ds.depth_c ** 2 + grid._ds.y_c ** 2).chunk(3)
-        da.coords["depth_c"] = grid._ds.depth_c
-        da.coords["y_c"] = grid._ds.y_c
-
-        diffed = (da.roll(depth_c=-1, roll_coords=False) - da).data
-        expected = xr.DataArray(
-            diffed,
-            dims=["depth_r", "y_c"],
-            coords={"depth_r": grid._ds.depth_r, "y_c": grid._ds.y_c},
-        ).compute()
-
-        result = grid.diff(da, axis="depth", to="right").compute()
         assert_equal(result, expected)
 
     @pytest.mark.xfail
@@ -741,6 +700,21 @@ class TestDaskOverlap:
                 map_overlap=True,
                 dask="allowed",
             )
+
+
+# TODO tests for handling dask in gri.diff etc. should eventually live in test_grid.py
+def test_grid_diff_center_to_right_1d():
+    grid = create_1d_test_grid("depth")
+    da = np.sin(grid._ds.depth_c * 2 * np.pi / 9).chunk(1)
+    da.coords["depth_c"] = grid._ds.depth_c
+
+    diffed = (da.roll(depth_c=-1, roll_coords=False) - da).data
+    expected = xr.DataArray(
+        diffed, dims=["depth_r"], coords={"depth_r": grid._ds.depth_r}
+    ).compute()
+
+    result = grid.diff(da, axis="depth", to="right").compute()
+    assert_equal(result, expected)
 
 
 class TestSignaturesEquivalent:

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -81,7 +81,7 @@ class TestParseGridUfuncSignature:
             _parse_grid_ufunc_signature(signature)
 
 
-def create_1d_test_grid_ds(ax_name):
+def create_1d_test_grid_ds(ax_name, length):
 
     grid_ds = xr.Dataset(
         coords={
@@ -89,25 +89,25 @@ def create_1d_test_grid_ds(ax_name):
                 [
                     f"{ax_name}_c",
                 ],
-                np.arange(1, 10),
+                np.arange(1, length + 1),
             ),
             f"{ax_name}_g": (
                 [
                     f"{ax_name}_g",
                 ],
-                np.arange(0.5, 9),
+                np.arange(0.5, length),
             ),
             f"{ax_name}_r": (
                 [
                     f"{ax_name}_r",
                 ],
-                np.arange(1.5, 10),
+                np.arange(1.5, length + 1),
             ),
             f"{ax_name}_i": (
                 [
                     f"{ax_name}_i",
                 ],
-                np.arange(1.5, 9),
+                np.arange(1.5, length),
             ),
             f"{ax_name}_o": (
                 [
@@ -121,8 +121,8 @@ def create_1d_test_grid_ds(ax_name):
     return grid_ds
 
 
-def create_1d_test_grid(ax_name):
-    grid_ds = create_1d_test_grid_ds(ax_name)
+def create_1d_test_grid(ax_name, length=9):
+    grid_ds = create_1d_test_grid_ds(ax_name, length)
     return Grid(
         grid_ds,
         coords={
@@ -137,9 +137,9 @@ def create_1d_test_grid(ax_name):
     )
 
 
-def create_2d_test_grid(ax_name_1, ax_name_2):
-    grid_ds_1 = create_1d_test_grid_ds(ax_name_1)
-    grid_ds_2 = create_1d_test_grid_ds(ax_name_2)
+def create_2d_test_grid(ax_name_1, ax_name_2, length1=9, length2=11):
+    grid_ds_1 = create_1d_test_grid_ds(ax_name_1, length1)
+    grid_ds_2 = create_1d_test_grid_ds(ax_name_2, length2)
 
     return Grid(
         ds=xr.merge([grid_ds_1, grid_ds_2]),

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -577,6 +577,46 @@ class TestDaskOverlap:
         ).compute()
         assert_equal(result, expected)
 
+    def test_chunked_core_dims_unchanging_chunksize_center_to_right(self):
+        # attempt to debug GH #438
+
+        def diff_center_to_right(a):
+            return a[..., 1:] - a[..., :-1]
+
+        grid = create_1d_test_grid("depth")
+        da = np.sin(grid._ds.depth_c * 2 * np.pi / 9).chunk(1)
+        da.coords["depth_c"] = grid._ds.depth_c
+
+        diffed = (da.roll(depth_c=-1, roll_coords=False) - da).data
+        expected = xr.DataArray(
+            diffed, dims=["depth_r"], coords={"depth_r": grid._ds.depth_r}
+        ).compute()
+
+        result = grid.diff(da, axis="depth", to="right").compute()
+        assert_equal(result, expected)
+
+    def test_chunked_core_dims_unchanging_chunksize_center_to_right_2d(self):
+        # attempt to debug GH #438
+
+        def diff_center_to_right(a):
+            return a[..., 1:] - a[..., :-1]
+
+        grid = create_2d_test_grid("depth", "y")
+
+        da = (grid._ds.depth_c ** 2 + grid._ds.y_c ** 2).chunk(3)
+        da.coords["depth_c"] = grid._ds.depth_c
+        da.coords["y_c"] = grid._ds.y_c
+
+        diffed = (da.roll(depth_c=-1, roll_coords=False) - da).data
+        expected = xr.DataArray(
+            diffed,
+            dims=["depth_r", "y_c"],
+            coords={"depth_r": grid._ds.depth_r, "y_c": grid._ds.y_c},
+        ).compute()
+
+        result = grid.diff(da, axis="depth", to="right").compute()
+        assert_equal(result, expected)
+
     @pytest.mark.xfail
     def test_num_tasks_regression(self):
         # Assert numbr of tasks in optimized graph is <= some hardcoded number
@@ -621,7 +661,7 @@ class TestDaskOverlap:
     def test_only_some_core_dims_are_chunked(self):
         raise NotImplementedError
 
-    def test_ufunc_changes_chunksize(self):
+    def test_raise_when_ufunc_changes_chunksize(self):
         @as_grid_ufunc(
             "(X:outer)->(X:center)",
             boundary_width={"X": (1, 0)},


### PR DESCRIPTION
This closes #429, but only works for 1D data if any core dims are chunked. I'll raise a separate issue for the 2D problem.

 - [x] Closes #429
 - [x] Tests added (just one for now, )
 - [x] Passes `pre-commit run --all-files`