### PR TITLE
Signature class + refactor inside apply_as_grid_ufunc

### DIFF
--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -29,6 +29,12 @@ except ImportError:
 
 from typing import Any, Dict, Iterable, List, Union
 
+# Only need this until python 3.8
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
+
 docstrings = docrep.DocstringProcessor(doc_key="My doc string")
 
 
@@ -1860,7 +1866,7 @@ class Grid:
         boundary_width=None,
         boundary=None,
         fill_value=None,
-        dask="forbidden",
+        dask: Literal["forbidden", "parallelized", "allowed"],
         **kwargs,
     ):
         """

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -8,10 +8,16 @@ from collections import OrderedDict
 import docrep  # type: ignore
 import numpy as np
 import xarray as xr
+from dask.array import Array as Dask_Array
 
 from . import comodo, gridops
 from .duck_array_ops import _apply_boundary_condition, _pad_array, concatenate
-from .grid_ufunc import GridUFunc, _signatures_equivalent, apply_as_grid_ufunc
+from .grid_ufunc import (
+    GridUFunc,
+    _has_chunked_core_dims,
+    _signatures_equivalent,
+    apply_as_grid_ufunc,
+)
 from .metrics import iterate_axis_combinations
 
 try:
@@ -1760,6 +1766,12 @@ class Grid:
 
         signatures = self._create_1d_grid_ufunc_signatures(da, axis=axis, to=to)
 
+        # if any dims are chunked then we need dask
+        if isinstance(da.data, Dask_Array):
+            dask = "parallelized"
+        else:
+            dask = "forbidden"
+
         array = da
         # Apply 1D function over multiple axes
         # TODO This will call xarray.apply_ufunc once for each axis, but if signatures + kwargs are the same then we
@@ -1775,8 +1787,25 @@ class Grid:
                 metric = self.get_metric(array, ax_metric_weighted)
                 array = array * metric
 
+            # if chunked along core dim then we need map_overlap
+            print(type(array.data))
+            core_dim = self._get_dims_from_axis(da, ax_name)
+            print(core_dim)
+            print(remaining_kwargs)
+            if _has_chunked_core_dims(array, core_dim):
+                map_overlap = True
+                dask = "allowed"
+            else:
+                map_overlap = False
+
             array = grid_ufunc(
-                self, array, axis=[ax_name], keep_coords=keep_coords, **remaining_kwargs
+                self,
+                array,
+                axis=[ax_name],
+                keep_coords=keep_coords,
+                dask=dask,
+                map_overlap=map_overlap,
+                **remaining_kwargs,
             )
 
             if ax_metric_weighted:

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     numba = None
 
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Tuple, Union
 
 # Only need this until python 3.8
 try:
@@ -1860,13 +1860,14 @@ class Grid:
 
     def apply_as_grid_ufunc(
         self,
-        func,
-        *args,
-        signature="",
-        boundary_width=None,
-        boundary=None,
-        fill_value=None,
-        dask: Literal["forbidden", "parallelized", "allowed"],
+        func: Callable,
+        *args: xr.DataArray,
+        signature: Union[str, Signature] = "",
+        boundary_width: Mapping[str, Tuple[int, int]] = None,
+        boundary: Union[str, Mapping[str, str]] = None,
+        fill_value: Union[float, Mapping[str, float]] = None,
+        dask: Literal["forbidden", "parallelized", "allowed"] = "forbidden",
+        map_overlap: bool = False,
         **kwargs,
     ):
         """
@@ -1932,6 +1933,7 @@ class Grid:
             boundary=boundary,
             fill_value=fill_value,
             dask=dask,
+            map_overlap=map_overlap,
             **kwargs,
         )
 

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -6,13 +6,18 @@ from typing import (
     Callable,
     Dict,
     List,
-    Literal,
     Mapping,
     Optional,
     Sequence,
     Tuple,
     Union,
 )
+
+# Only need this until python 3.8
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
 
 import numpy as np
 import xarray as xr
@@ -320,7 +325,7 @@ def apply_as_grid_ufunc(
     boundary: Union[str, Mapping[str, str]] = None,
     fill_value: Union[float, Mapping[str, float]] = None,
     keep_coords: bool = True,
-    dask: str = "forbidden",
+    dask: Literal["forbidden", "parallelized", "allowed"],
     map_overlap: bool = False,
     **kwargs,
 ) -> List[Any]:

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -133,11 +133,15 @@ class Signature:
         identical, the signatures must not be equivalent. Axes positions do have to match exactly.
         """
 
-        sig1_in, sig1_out = self.in_ax_names, self.out_ax_names
-        sig2_in, sig2_out = other.in_ax_names, other.out_ax_names
+        def set_unique_inds(sig_part):
+            return set([i for arg in sig_part for i in arg])
 
-        all_unique_sig1_indices = set([i for arg in sig1_in for i in arg])
-        all_unique_sig2_indices = set([i for arg in sig2_in for i in arg])
+        all_unique_sig1_indices = set_unique_inds(self.in_ax_names) | set_unique_inds(
+            self.out_ax_names
+        )
+        all_unique_sig2_indices = set_unique_inds(other.in_ax_names) | set_unique_inds(
+            other.out_ax_names
+        )
 
         if len(all_unique_sig1_indices) != len(all_unique_sig2_indices):
             return False

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -437,7 +437,7 @@ def apply_as_grid_ufunc(
         # map operation over dask chunks along core dimensions
         from dask.array import map_overlap as dask_map_overlap  # type: ignore
 
-        # Need to tranpose the numpy axis arguments to leave core dims at end
+        # Need to transpose the numpy axis arguments to leave core dims at end
         # else they won't match up inside mapped_func after xr.apply_ufunc does its transposition
         transposed_original_args = [
             arg.transpose(..., *in_core_dims[i]) for i, arg in enumerate(args)
@@ -456,6 +456,7 @@ def apply_as_grid_ufunc(
         def _dict_to_numbered_axes(
             sizes: Mapping[str, single_dim_chunktype]
         ) -> Tuple[single_dim_chunktype, ...]:
+            """This implicitly crystallises the order of the given mapping"""
             return tuple(sizes.values())
 
         # Our rechunking means dask.map_overlap needs to be explicitly told what chunks output should have

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -333,6 +333,14 @@ def apply_as_grid_ufunc(
     xarray.apply_ufunc
     """
 
+    print(args[0].chunksizes)
+    print(axis)
+    print(signature)
+    print(boundary_width)
+    print(boundary)
+    print(dask)
+    print(map_overlap)
+
     if grid is None:
         raise ValueError("Must provide a grid object to describe the Axes")
 
@@ -464,6 +472,7 @@ def apply_as_grid_ufunc(
         # (we don't need a separate code path using bare map_blocks if boundary_widths are zero because map_overlap just
         # calls map_blocks automatically in that scenario)
         def mapped_func(*a, **kw):
+            # print(type(a[0]))
             return dask_map_overlap(
                 func,
                 *a,
@@ -544,11 +553,12 @@ def apply_as_grid_ufunc(
     return results_with_coords
 
 
-def _has_chunked_core_dims(obj: xr.DataArray, core_dims: Sequence[str]) -> bool:
-    def is_dim_chunked(a, dim):
-        # TODO this func can't handle Datasets - it will error if you check multiple variables with different chunking
-        return len(a.variable.chunksizes[dim]) > 1
+def is_dim_chunked(a, dim):
+    # TODO this func can't handle Datasets - it will error if you check multiple variables with different chunking
+    return len(a.variable.chunksizes[dim]) > 1
 
+
+def _has_chunked_core_dims(obj: xr.DataArray, core_dims: Sequence[str]) -> bool:
     # TODO what if only some of the core dimensions are chunked?
     return obj.chunks is not None and any(is_dim_chunked(obj, dim) for dim in core_dims)
 

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -325,7 +325,7 @@ def apply_as_grid_ufunc(
     boundary: Union[str, Mapping[str, str]] = None,
     fill_value: Union[float, Mapping[str, float]] = None,
     keep_coords: bool = True,
-    dask: Literal["forbidden", "parallelized", "allowed"],
+    dask: Literal["forbidden", "parallelized", "allowed"] = "forbidden",
     map_overlap: bool = False,
     **kwargs,
 ) -> List[Any]:

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -701,6 +701,32 @@ def test_multi_axis_input(all_datasets, func, periodic, boundary):
         xr.testing.assert_allclose(serial, full)
 
 
+@pytest.mark.skip
+@pytest.mark.parametrize("func", ["interp", "max", "min", "diff", "cumsum"])
+@pytest.mark.parametrize("periodic", ["True", "False", ["X"], ["Y"], ["X", "Y"]])
+@pytest.mark.parametrize(
+    "boundary",
+    [
+        "fill",
+        # "extrapolate", # do we not support extrapolation anymore?
+        "extend",
+        {"X": "fill", "Y": "extend"},
+        {"X": "extend", "Y": "fill"},
+    ],
+)
+def test_dask_vs_eager(all_datasets, func, periodic, boundary):
+    ds, coords, metrics = datasets_grid_metric("C")
+    grid = Grid(ds, coords=coords)
+
+    eager_result = grid.diff(ds.tracer, "X")
+
+    ds = ds.chunk({"xt": 1, "yt": 1, "time": 1, "zt": 1})
+    grid = Grid(ds, coords=coords)
+    dask_result = grid.diff(ds.tracer, "X").compute()
+
+    xr.testing.assert_identical(dask_result, eager_result)
+
+
 def test_grid_dict_input_boundary_fill(nonperiodic_1d):
     """Test axis kwarg input functionality using dict input"""
     ds, _, _ = nonperiodic_1d

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -701,7 +701,6 @@ def test_multi_axis_input(all_datasets, func, periodic, boundary):
         xr.testing.assert_allclose(serial, full)
 
 
-@pytest.mark.skip
 @pytest.mark.parametrize("func", ["interp", "max", "min", "diff", "cumsum"])
 @pytest.mark.parametrize("periodic", ["True", "False", ["X"], ["Y"], ["X", "Y"]])
 @pytest.mark.parametrize(

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -81,7 +81,7 @@ class TestParseGridUfuncSignature:
             _parse_grid_ufunc_signature(signature)
 
 
-def create_1d_test_grid_ds(ax_name):
+def create_1d_test_grid_ds(ax_name, length):
 
     grid_ds = xr.Dataset(
         coords={
@@ -89,25 +89,25 @@ def create_1d_test_grid_ds(ax_name):
                 [
                     f"{ax_name}_c",
                 ],
-                np.arange(1, 10),
+                np.arange(1, length + 1),
             ),
             f"{ax_name}_g": (
                 [
                     f"{ax_name}_g",
                 ],
-                np.arange(0.5, 9),
+                np.arange(0.5, length),
             ),
             f"{ax_name}_r": (
                 [
                     f"{ax_name}_r",
                 ],
-                np.arange(1.5, 10),
+                np.arange(1.5, length + 1),
             ),
             f"{ax_name}_i": (
                 [
                     f"{ax_name}_i",
                 ],
-                np.arange(1.5, 9),
+                np.arange(1.5, length),
             ),
             f"{ax_name}_o": (
                 [
@@ -121,8 +121,8 @@ def create_1d_test_grid_ds(ax_name):
     return grid_ds
 
 
-def create_1d_test_grid(ax_name):
-    grid_ds = create_1d_test_grid_ds(ax_name)
+def create_1d_test_grid(ax_name, length=9):
+    grid_ds = create_1d_test_grid_ds(ax_name, length)
     return Grid(
         grid_ds,
         coords={
@@ -137,9 +137,9 @@ def create_1d_test_grid(ax_name):
     )
 
 
-def create_2d_test_grid(ax_name_1, ax_name_2):
-    grid_ds_1 = create_1d_test_grid_ds(ax_name_1)
-    grid_ds_2 = create_1d_test_grid_ds(ax_name_2)
+def create_2d_test_grid(ax_name_1, ax_name_2, length1=9, length2=11):
+    grid_ds_1 = create_1d_test_grid_ds(ax_name_1, length1)
+    grid_ds_2 = create_1d_test_grid_ds(ax_name_2, length2)
 
     return Grid(
         ds=xr.merge([grid_ds_1, grid_ds_2]),


### PR DESCRIPTION
Refactors grid_ufunc internals by splitting things up into smaller functions. Also adds a `Signature` class, which is neat, but I'm not sure it needs to be exposed to users.

 - [x] Passes `pre-commit run --all-files`