### PR TITLE
added missed keyword arguments

### DIFF
--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     numba = None
 
-from typing import Any, Callable, Dict, Iterable, List, Mapping, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Sequence, Tuple, Union
 
 # Only need this until python 3.8
 try:
@@ -1862,6 +1862,7 @@ class Grid:
         self,
         func: Callable,
         *args: xr.DataArray,
+        axis: Sequence[Sequence[str]] = None,
         signature: Union[str, Signature] = "",
         boundary_width: Mapping[str, Tuple[int, int]] = None,
         boundary: Union[str, Mapping[str, str]] = None,
@@ -1884,6 +1885,11 @@ class Grid:
             arrays (`.data`).
 
             Passed directly on to `xarray.apply_ufunc`.
+        *args : xarray.DataArray
+            One or more xarray DataArray objects to apply the function to.
+        axis : Sequence[Sequence[str]], optional
+            Names of xgcm.Axes on which to act, for each array in args. Multiple axes can be passed as a sequence (e.g. ``['X', 'Y']``).
+            Function will be executed over all Axes simultaneously, and each Axis must be present in the Grid.
         signature : string
             Grid universal function signature. Specifies the xgcm.Axis names and
             positions for each input and output variable, e.g.,
@@ -1911,6 +1917,9 @@ class Grid:
         dask : {"forbidden", "allowed", "parallelized"}, default: "forbidden"
             How to handle applying to objects containing lazy data in the form of
             dask arrays. Passed directly on to `xarray.apply_ufunc`.
+        map_overlap : bool, optional
+            Whether or not to automatically apply the function along chunked core dimensions using dask.array.map_overlap.
+            Default is False. If True, will need to be accompanied by dask='allowed'.
 
         Returns
         -------
@@ -1927,6 +1936,7 @@ class Grid:
         return apply_as_grid_ufunc(
             func,
             *args,
+            axis=axis,
             grid=self,
             signature=signature,
             boundary_width=boundary_width,

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -318,7 +318,7 @@ def as_grid_ufunc(
 def apply_as_grid_ufunc(
     func: Callable,
     *args: xr.DataArray,
-    axis: Sequence[str],
+    axis: Sequence[Sequence[str]] = None,
     grid: "Grid" = None,
     signature: Union[str, Signature] = "",
     boundary_width: Mapping[str, Tuple[int, int]] = None,
@@ -345,7 +345,7 @@ def apply_as_grid_ufunc(
         Passed directly on to `xarray.apply_ufunc`.
     *args : xarray.DataArray
         One or more xarray DataArray objects to apply the function to.
-    axis : Sequence[Tuple[str]]
+    axis : Sequence[Sequence[str]], optional
         Names of xgcm.Axes on which to act, for each array in args. Multiple axes can be passed as a sequence (e.g. ``['X', 'Y']``).
         Function will be executed over all Axes simultaneously, and each Axis must be present in the Grid.
     grid : xgcm.Grid
@@ -412,6 +412,9 @@ def apply_as_grid_ufunc(
 
     if any(not isinstance(arg, xr.DataArray) for arg in args):
         raise TypeError("All data arguments must be of type DataArray")
+
+    if axis is None:
+        raise ValueError("Must provide an axis along which to apply the grid ufunc")
 
     if len(args) != len(axis):
         raise ValueError(
@@ -725,7 +728,7 @@ def _get_dim(grid: "Grid", da: xr.DataArray, ax_name: str) -> str:
 
 
 def _identify_dummy_axes_with_real_axes(
-    sig_in_dummy_ax_names: List[Tuple[str, ...]], axis: Sequence[str]
+    sig_in_dummy_ax_names: List[Tuple[str, ...]], axis: Sequence[Sequence[str]]
 ) -> Mapping[str, str]:
     """Create a mapping between the dummy axis names in the signature and the real axis names of the data passed."""
 


### PR DESCRIPTION
These arguments should have been in the signatures explicitly the whole time, it only worked because they were being passed down through `**kwargs`.