### PR TITLE
Padding inside ufunc

### DIFF
--- a/xgcm/padding.py
+++ b/xgcm/padding.py
@@ -1,0 +1,132 @@
+from typing import Callable, Tuple, Mapping
+
+import numpy as np
+
+
+class Padder:
+    """
+    Internal class which can pad numpy arrays, or compose a numpy ufunc with a particular padding operation.
+
+    One instance of the Padder class should be used for one padding operation, as its internals store the options chosen
+    for that particular use.
+    """
+    grid: "Grid"
+    boundary_width: ...  # TODO work out what all these types need to be
+    boundary: ...
+    fill_value: ...
+
+    def __init__(self, grid, boundary_width, boundary, fill_value):
+        self.grid = grid
+        self.boundary_width = boundary_width
+        self.boundary = boundary
+        self.fill_value = fill_value
+
+    def pad(self, *arrays: np.ndarray) -> Tuple[np.ndarray]:
+
+        # do the padding
+        padded_arrs = ...
+
+        # merge any lonely chunks on either end created by padding
+        if any(
+                _has_chunked_core_dims(padded_arg, core_dims)
+                for padded_arr, core_dims in zip(padded_arrs, in_core_dims)
+        ):
+            return self.merge_boundary_chunks(arrays)
+        else:
+            return arrays
+
+    def merge_boundary_chunks(
+        self,
+        *arrs: np.ndarray,
+        original_chunks: Mapping[int, Tuple[int, int]],
+    ) -> Tuple[np.ndarray]:
+        """Merge in any small floating chunks at the edges that were created by the padding operation"""
+        ...
+
+    def compose_with(self, func: Callable) -> Callable:
+        """Return a new function which first pads its arguments and then applies `func` to them."""
+
+        def pad_then_func(*args, **kwargs):
+            padded_args = self.pad(*args)
+            return func(*padded_args, **kwargs)
+
+        return pad_then_func
+
+
+### ignore past here for now
+
+
+def _is_dim_chunked(a, dim):
+    # TODO this func can't handle Datasets - it will error if you check multiple variables with different chunking
+    return len(a.variable.chunksizes[dim]) > 1
+
+
+def _has_chunked_core_dims(obj: xr.DataArray, core_dims: Sequence[str]) -> bool:
+    # TODO what if only some of the core dimensions are chunked?
+    return obj.chunks is not None and any(
+        _is_dim_chunked(obj, dim) for dim in core_dims
+    )
+
+
+def _rechunk_to_merge_in_boundary_chunks(
+    padded_args: Sequence[xr.DataArray],
+    original_args: Sequence[xr.DataArray],
+    boundary_width_real_axes: Mapping[str, Tuple[int, int]],
+    grid: "Grid",
+) -> List[xr.DataArray]:
+    """Merges in any small floating chunks at the edges that were created by the padding operation"""
+
+    rechunked_padded_args = []
+    for padded_arg, original_arg in zip(padded_args, original_args):
+
+        original_arg_chunks = original_arg.variable.chunksizes
+        merged_boundary_chunks = _get_chunk_pattern_for_merging_boundary(
+            grid,
+            padded_arg,
+            original_arg_chunks,
+            boundary_width_real_axes,
+        )
+        rechunked_arg = padded_arg.chunk(merged_boundary_chunks)
+        rechunked_padded_args.append(rechunked_arg)
+
+    return rechunked_padded_args
+
+
+def _get_chunk_pattern_for_merging_boundary(
+    grid: "Grid",
+    da: xr.DataArray,
+    original_chunks: Mapping[str, Tuple[int, ...]],
+    boundary_width_real_axes: Mapping[str, Tuple[int, int]],
+) -> Mapping[str, Tuple[int, ...]]:
+    """Calculates the pattern of chunking needed to merge back in small chunks left on boundaries after padding"""
+
+    # Easier to work with width of boundaries in terms of str dimension names rather than int axis numbers
+    boundary_width_dims = {
+        _get_dim(grid, da, ax): width for ax, width in boundary_width_real_axes.items()
+    }
+
+    new_chunks: Dict[str, Tuple[int, ...]] = {}
+    for dim, width in boundary_width_dims.items():
+        lower_boundary_width, upper_boundary_width = boundary_width_dims[dim]
+
+        new_chunks_along_dim: Tuple[int, ...]
+        if len(original_chunks[dim]) == 1:
+            # unpadded array had only one chunk, but padding has meant new array is extended
+            original_array_length = original_chunks[dim][0]
+            new_chunks_along_dim = (
+                lower_boundary_width + original_array_length + upper_boundary_width,
+            )
+        else:
+            first_chunk_width, *other_chunks_widths, last_chunk_width = original_chunks[
+                dim
+            ]
+            new_chunks_along_dim = tuple(
+                [
+                    first_chunk_width + lower_boundary_width,
+                    *other_chunks_widths,
+                    last_chunk_width + upper_boundary_width,
+                ]
+            )
+        new_chunks[dim] = new_chunks_along_dim
+
+    return new_chunks

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -162,7 +162,7 @@ def create_2d_test_grid(ax_name_1, ax_name_2, length1=9, length2=11):
     )
 
 
-class TestGridUFunc:
+class TestGridUFuncNoPadding:
     def test_stores_ufunc_kwarg_info(self):
         signature = "(X:center)->(X:left)"
 
@@ -235,63 +235,6 @@ class TestGridUFunc:
             return a - np.roll(a, shift=-1)
 
         result = diff_center_to_left(grid, da, axis=[("depth",)])
-        assert_equal(result, expected)
-
-    def test_1d_unchanging_size_but_padded_dask_parallelized(self):
-        """
-        This test checks that the process of padding a non-chunked core dimension doesn't turn it into a chunked core
-        dimension. See GH #430.
-        """
-
-        def diff_center_to_left(a):
-            return a[..., 1:] - a[..., :-1]
-
-        grid = create_1d_test_grid("depth")
-        da = np.sin(grid._ds.depth_c * 2 * np.pi / 9).chunk()
-        da.coords["depth_c"] = grid._ds.depth_c
-
-        diffed = (da - da.roll(depth_c=1, roll_coords=False)).data
-        expected = xr.DataArray(
-            diffed, dims=["depth_g"], coords={"depth_g": grid._ds.depth_g}
-        ).compute()
-
-        # Test direct application
-        result = apply_as_grid_ufunc(
-            diff_center_to_left,
-            da,
-            axis=[("depth",)],
-            grid=grid,
-            signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
-            dask="parallelized",
-        ).compute()
-        assert_equal(result, expected)
-
-        # Test Grid method
-        result = grid.apply_as_grid_ufunc(
-            diff_center_to_left,
-            da,
-            axis=[("depth",)],
-            signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
-            dask="parallelized",
-        )
-        assert_equal(result, expected)
-
-        # Test decorator
-        @as_grid_ufunc(
-            "(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
-            dask="parallelized",
-        )
-        def diff_center_to_left(a):
-            return a[..., 1:] - a[..., :-1]
-
-        result = diff_center_to_left(
-            grid,
-            da,
-            axis=[("depth",)],
-        ).compute()
         assert_equal(result, expected)
 
     def test_1d_changing_size_dask_parallelized(self):
@@ -420,8 +363,6 @@ class TestGridUFunc:
         result = diff_center_to_left(grid, da, axis=[("lon",)])
         assert_equal(result, expected)
 
-    # TODO test a function with padding
-
     def test_multiple_inputs(self):
         def inner_product_left_right(a, b):
             return np.inner(a, b)
@@ -509,6 +450,122 @@ class TestGridUFunc:
         u, v = grad_to_inner(grid, a, axis=[("lon", "lat")])
         assert_equal(u.T, expected_u)
         assert_equal(v, expected_v)
+
+
+class TestGridUfuncWithPadding:
+    def test_1d_padded_but_no_change_in_grid_position(self):
+        def diff_center_to_center_second_order(a):
+            return 0.5 * (a[..., 2:] - a[..., :-2])
+
+        grid = create_1d_test_grid("depth")
+        da = np.sin(grid._ds.depth_c * 2 * np.pi / 9)
+        da.coords["depth_c"] = grid._ds.depth_c
+
+        diffed = (da - da.roll(depth_c=-2, roll_coords=False)).data
+        expected = xr.DataArray(
+            diffed, dims=["depth_c"], coords={"depth_c": grid._ds.depth_c}
+        )
+
+        # Test direct application
+        result = apply_as_grid_ufunc(
+            diff_center_to_center_second_order,
+            da,
+            axis=[("depth",)],
+            grid=grid,
+            signature="(X:center)->(X:center)",
+            boundary_width={"X": (2, 0)},
+        )
+        assert_equal(result, expected)
+
+    def test_1d_unchanging_size_but_padded_dask_parallelized(self):
+        """
+        This test checks that the process of padding a non-chunked core dimension doesn't turn it into a chunked core
+        dimension. See GH #430.
+        """
+
+        def diff_center_to_left(a):
+            return a[..., 1:] - a[..., :-1]
+
+        grid = create_1d_test_grid("depth")
+        da = np.sin(grid._ds.depth_c * 2 * np.pi / 9).chunk()
+        da.coords["depth_c"] = grid._ds.depth_c
+
+        diffed = (da - da.roll(depth_c=1, roll_coords=False)).data
+        expected = xr.DataArray(
+            diffed, dims=["depth_g"], coords={"depth_g": grid._ds.depth_g}
+        ).compute()
+
+        # Test direct application
+        result = apply_as_grid_ufunc(
+            diff_center_to_left,
+            da,
+            axis=[("depth",)],
+            grid=grid,
+            signature="(X:center)->(X:left)",
+            boundary_width={"X": (1, 0)},
+            dask="parallelized",
+        ).compute()
+        assert_equal(result, expected)
+
+        # Test Grid method
+        result = grid.apply_as_grid_ufunc(
+            diff_center_to_left,
+            da,
+            axis=[("depth",)],
+            signature="(X:center)->(X:left)",
+            boundary_width={"X": (1, 0)},
+            dask="parallelized",
+        )
+        assert_equal(result, expected)
+
+        # Test decorator
+        @as_grid_ufunc(
+            "(X:center)->(X:left)",
+            boundary_width={"X": (1, 0)},
+            dask="parallelized",
+        )
+        def diff_center_to_left(a):
+            return a[..., 1:] - a[..., :-1]
+
+        result = diff_center_to_left(
+            grid,
+            da,
+            axis=[("depth",)],
+        ).compute()
+        assert_equal(result, expected)
+
+    def test_2d_padding(self):
+        def diff(a, axis):
+            def _diff(a):
+                return a[..., 1:] - a[..., :-1]
+
+            return np.apply_along_axis(_diff, axis, a)
+
+        def vort(u, v):
+            """This needs to return an array 1 element smaller along both axis -1 & -2."""
+
+            u_trimmed = u[..., 1:]
+            v_trimmed = v[..., 1:, :]
+
+            result = diff(v_trimmed, axis=-1) - diff(u_trimmed, axis=-2)
+            return result
+
+        grid = create_2d_test_grid("lon", "lat")
+
+        U = grid._ds.lon_g ** 2 + grid._ds.lat_c ** 3
+        V = grid._ds.lon_c ** 3 + grid._ds.lat_g ** 2
+
+        grid.apply_as_grid_ufunc(
+            vort,
+            U,
+            V,
+            axis=2 * [("lon", "lat")],
+            signature="(lon:left,lat:center),(lon:center,lat:left)->(lon:left,lat:left)",
+            boundary_width={"lon": (1, 0), "lat": (1, 0)},
+            dask="parallelized",  # data isn't chunked along lat/lon
+        )
+
+        # TODO asserts
 
 
 class TestDaskNoOverlap:

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -462,7 +462,7 @@ class TestGridUfuncWithPadding:
         da = np.sin(grid._ds.depth_c * 2 * np.pi / 9)
         da.coords["depth_c"] = grid._ds.depth_c
 
-        diffed = (da - da.roll(depth_c=-2, roll_coords=False)).data
+        diffed = (da - da.roll(depth_c=2, roll_coords=False)).data
         expected = xr.DataArray(
             diffed, dims=["depth_c"], coords={"depth_c": grid._ds.depth_c}
         )


### PR DESCRIPTION
Sketch of how we might refactor the code to pad inside the ufunc, as discussed in #443.

The idea is that all the complexity of composing the the padding operation with the desired ufunc operation is abstracted away into this `Padder` class, making `apply_as_grid_ufunc` as simple as possible to understand.

Also adds tests for the bug described in #436.

 - [x] Intended to eventually close #436 and #443
 - [x] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
