### PR TITLE
Ufunc examples docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -19,8 +19,8 @@ Grid ufuncs
 .. autosummary::
    :toctree: generated/
 
-   apply_grid_ufunc
-   as_grid_ufunc
+   xgcm.apply_as_grid_ufunc
+   xgcm.as_grid_ufunc
 
 autogenerate
 ============

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
+    "sphinx_panels",
     "numpydoc",
     "nbsphinx",
     "IPython.sphinxext.ipython_directive",

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,6 +1,6 @@
 name: test_env_xgcm_docs
 dependencies:
-  - python=3.6
+  - python=3.9
   - xarray
   - netcdf4
   - cartopy
@@ -11,6 +11,7 @@ dependencies:
   - pytest
   - numpydoc
   - sphinx
+  - sphinx-panels
   - ipython
   - matplotlib
   - sphinx_rtd_theme

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - matplotlib
   - sphinx_rtd_theme
   - ipykernel
-  - python-graphviz
+#  - python-graphviz
   - pip:
     - docrep<=0.2.7
     - nbsphinx

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - pytest
   - numpydoc
   - sphinx
-  - ipython
   - matplotlib
   - sphinx_rtd_theme
   - ipykernel
@@ -23,3 +22,4 @@ dependencies:
     - sphinx-copybutton
     - sphinxcontrib-srclinks
     - sphinx-panels
+    - git+https://github.com/TomNicholas/ipython.git@dont_strip_all_decorators2

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - pytest
   - numpydoc
   - sphinx
-  - sphinx-panels
   - ipython
   - matplotlib
   - sphinx_rtd_theme
@@ -23,3 +22,4 @@ dependencies:
     - sphinx_pangeo_theme
     - sphinx-copybutton
     - sphinxcontrib-srclinks
+    - sphinx-panels

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - matplotlib
   - sphinx_rtd_theme
   - ipykernel
+  - python-graphviz
   - pip:
     - docrep<=0.2.7
     - nbsphinx

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -149,6 +149,7 @@ Alternatively you can permanently turn a numpy function into a grid ufunc by usi
 Now when we call the ``diff_forward`` function, it will act as if we had applied it using ``apply_as_grid_ufunc``.
 
 .. ipython:: python
+    :okexcept:
 
     diff_forward(grid, da, axis=[["X"]])
 
@@ -158,12 +159,16 @@ Decorator with type hints
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Finally you can use type hints to specify the grid positions of the variables instead of passing a ``signature`` argument.
-::
+
+.. ipython:: python
+    :okexcept:
 
     from xgcm import Gridded
 
     @as_grid_ufunc()
-    def diff_forward(a: Gridded[np.ndarray, "ax1:center"]) -> Gridded[np.ndarray, "ax1:left"]:
+    def diff_forward(
+        a: Gridded[np.ndarray, "ax1:center"]
+    ) -> Gridded[np.ndarray, "ax1:left"]:
         return a - np.roll(a, -1, axis=-1)
 
 .. note::
@@ -173,19 +178,16 @@ Finally you can use type hints to specify the grid positions of the variables in
 Again we call this decorated function, remembering to supply the grid and axis arguments
 
 .. ipython:: python
+    :okexcept:
 
     diff_forward(grid, da, axis=[["X"]])
 
 The signature argument is incompatible with using ``Gridded`` to annotate the types of any of the function arguments - i.e. you cannot mix the signature approach with the type hinting approach.
 
-A Simple Example
-^^^^^^^^^^^^^^^^
+.. note::
 
-- Can we think of one that has no boundary?
-- Something with an axis?
-- Mean
-
-.. _Boundaries and Padding:
+    If you want to use type hints to specify a signature with multiple return arguments, your return value should be type hinted as a tuple of annotated hints, e.g.
+    ``Tuple[Gridded[np.ndarray, "ax1:left"], Gridded[np.ndarray, "ax1:right"]]``.
 
 Boundaries and Padding
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -53,9 +53,10 @@ Each variable can be operated on along multiple axes, which are separated by a c
 
 The axis names used in the signature are dummy names: they do not have to be the same as the axis names used in your ``Grid`` object.
 This allows you to write a grid ufunc that can accept axis with any name.
-Therefore the signature ``"(ax1:center)->(ax1:left)"`` means all of
+Therefore the signature ``"(ax1:center)->(ax1:left)"`` means all of:
 
-`"This function accepts one data variable, which is one-dimensional and lies on the center grid positions of its singular axis.
+`"This function accepts one data variable and applies an operation over one core dimension.
+The input data lies on the center grid positions of the singular axis along which we will choose to apply the function.
 After performing its numerical operation the single return value from this function will have been shifted onto the left-hand grid positions of the same axis."`
 
 - Some simple examples, in a table

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -66,13 +66,14 @@ Lets imagine we have a numpy function which does forward differencing along one 
 
     import numpy as np
 
+
     def diff_forward(a):
         return a - np.roll(a, -1, axis=-1)
 
 All this function does is subtract each element of the given array from the element immediately to its right,
 with the ends of the array wrapped around in a periodic fashion.
 If we imagine this function acting on a variable located at the cell centers,
-our axis position diagram suggests that the result would lie on the left-hand cell edges.
+our :ref:`axis-positions` diagram suggests that the result would lie on the left-hand cell edges.
 Therefore the signature of this function could be
 ``"(ax1:center)->(ax1:left)"``.
 
@@ -149,6 +150,7 @@ Alternatively you can permanently turn a numpy function into a grid ufunc by usi
 
     from xgcm import as_grid_ufunc
 
+
     @as_grid_ufunc(signature="(ax1:center)->(ax1:left)")
     def diff_center_to_left(a):
         return diff_forward(a)
@@ -171,6 +173,7 @@ Finally you can use type hints to specify the grid positions of the variables in
     :okexcept:
 
     from xgcm import Gridded
+
 
     @as_grid_ufunc()
     def diff_center_to_left(
@@ -271,6 +274,7 @@ Now when we run our decorated function `interp_center_to_left`, xgcm will automa
 before applying the operation in the function we decorated.
 
 .. ipython:: python
+    :okexcept:
 
     da = xr.DataArray(arr)
 
@@ -279,6 +283,7 @@ before applying the operation in the function we decorated.
 It's used a periodic boundary condition as the default, but we can choose other boundary conditions using the ``boundary`` kwarg:
 
 .. ipython:: python
+    :okexcept:
 
     interp_center_to_left(grid, da, axis=[["X"]], boundary="constant", fill_value=0)
 

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -59,7 +59,47 @@ Therefore the signature ``"(ax1:center)->(ax1:left)"`` means all of:
 The input data lies on the center grid positions of the singular axis along which we will choose to apply the function.
 After performing its numerical operation the single return value from this function will have been shifted onto the left-hand grid positions of the same axis."`
 
-- Some simple examples, in a table
+To give you an idea of how we might use grid ufuncs here is a table of possible grid ufuncs and their corresponding signatures:
+
+.. list-table:: Example signatures for different grid ufuncs
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Name
+     - Signature
+     - Description
+   * - ``diff_center_to_left(a)``
+     - ``"(X:center)->(X:left)"``
+     - Backward difference
+   * - ``interp_center_to_left(a)``
+     - ``"(X:center)->(X:left)"``
+     - Backward interpolation
+   * - ``diff_left_to_center(a)``
+     - ``"(X:left)->(X:center)"``
+     - Forward difference
+   * - ``interp_left_to_center(a)``
+     - ``"(X:left)->(X:center)"``
+     - Forward interpolation
+   * - ``diff_center_to_center(a)``
+     - ``"(X:center)->(X:center)"``
+     - Second order central difference
+   * - ``mean_depth(w)``
+     - ``"(depth:center)->()"``
+     - Reduction
+   * - ``inner_product_left_right(a, b)``
+     - ``"(X:left),(X:right)->()"``
+     - Reduction of two variables
+   * - ``u_grid_vorticity(u, v)``
+     - ``"(lon:left,lat:center),``
+       ``(lon:center,lat:left)``
+       ``->(lon:left,lat:left)"``
+     - Complex example calculating vorticity on an Arakawa U-grid in 2D
+
+.. note::
+
+    Remember the axis names in the signature are dummy names - you could apply ``mean_depth`` along an axis not called
+    ``"depth"`` if you wish.
+
 
 Defining New Grid Ufuncs
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -1,0 +1,70 @@
+.. _grid_ufuncs:
+
+Grid Ufuncs
+-----------
+
+Concept of a Grid Ufunc
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Generalisation of numpy generalized ufuncs to include axis positions of input and output variables
+- Primer on numpy generalized ufuncs
+
+Specifying the ``signature``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Syntax
+- Dummy indices and naming conventions
+- Some simple examples
+- Can't supply data as kwargs
+
+Defining New Grid Ufuncs
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Syntax Choices
+^^^^^^^^^^^^^^
+
+- Decorator with signature
+- Decorator with type hints
+- Applying directly
+
+A Simple Example
+^^^^^^^^^^^^^^^^
+
+- Can we think of one that has no boundary?
+- Something with an axis?
+- Mean
+
+Boundaries and Padding
+~~~~~~~~~~~~~~~~~~~~~~
+
+- ``boundary_widths``
+- ``boundary``
+- 1D forward differencing?
+- Link to more specific docs?
+- Link to more complex examples?
+
+Metrics
+~~~~~~~
+
+- Specifying metrics
+- An example
+
+Parallelizing with Dask
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Parallelizing Along Broadcast Dimensions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Under the hood we first call ``xarray.apply_ufunc``
+- Primer on ``xarray.apply_ufunc``
+- The ``dask`` kwarg
+- Showing off the dask graph
+
+Parallelizing Along Core Dimensions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- We also optionally call ``dask.map_blocks``
+- Primer on ``dask.map_blocks``
+- The ``map_blocks`` kwarg
+- Rechunking that occurs when padding?
+- Showing off the dask graph

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -192,6 +192,60 @@ The signature argument is incompatible with using ``Gridded`` to annotate the ty
 Boundaries and Padding
 ~~~~~~~~~~~~~~~~~~~~~~
 
+Manually Applying Boundary Conditions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The example differencing function we used above had an implicit periodic boundary condition, but what if we wanted to use a different boundary condition?
+
+We'll show this using a simple linear interpolation function. It has the same signature at the differencing function we used above, but it does not apply any specific boundary condition.
+
+.. ipython:: python
+
+    def interp(a):
+        return 0.5 * (a[..., :-1] + a[..., 1:])
+
+This function simply averages each element from the one on its right, but that means the resulting array is shorter by one element.
+
+.. ipython:: python
+
+    arr = np.arange(10)
+    arr
+    arr.shape
+
+    interpolated = interp(arr)
+    interpolated
+    interpolated.shape
+
+Applying a boundary condition during this operation is equivalent to choosing how to pad the original array so that the application of ``interp`` still returns an array of the starting length.
+
+We could do this manually - implementing a periodic boundary condition would mean first pre-pending the right-most element of the input array onto the left-hand side:
+
+.. ipython:: python
+
+    periodically_padded_arr = np.insert(arr, 0, arr[-1])
+    periodically_padded_arr
+
+    interpolated_periodically = interp(periodically_padded_arr)
+    interpolated_periodically.shape
+
+and implementing a constant zero-padding boundary condition would mean first pre-pending the input array with a zero:
+
+.. ipython:: python
+
+    zero_padded_arr = np.insert(arr, 0, 0)
+    zero_padded_arr
+
+    interpolated_with_zero_padding = interp(zero_padded_arr)
+    interpolated_with_zero_padding
+    interpolated_with_zero_padding.shape
+
+In both cases the result has the same length as the original input array.
+We can also see that the result depends on the choice of boundary conditions.
+
+Automatically Applying Boundary Conditions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
 - ``boundary_width``
 - Relationship to padding
 - ``boundary``

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -7,11 +7,6 @@ Concept of a Grid Ufunc
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 In short, a "grid ufunc" is a generalisation of a `numpy generalized universal function`_ to include the xGCM Axes and Positions of input and output variables.
-We tell a function about the axes information through a ``signature``,
-which for a function which accepts data located at the center grid positions and returns
-data located on the same axis but now at the left-hand grid positions would look like:
-
-``"(ax1:center)->(ax1:left)"``.
 
 If you are not already familiar with numpy generalised universal functions (hereon referred to as "numpy ufuncs"),
 then here is a quick primer.
@@ -19,6 +14,13 @@ then here is a quick primer.
 .. dropdown:: **Primer on numpy generalized universal functions**
 
     Content about numpy...
+
+We tell a function about the axes information through a ``signature``.
+For example, imagine we have a function which accepts data located at the center grid positions and returns
+data located at the left-hand grid positions, on the same axis.
+The signature for this function would look like:
+
+``"(ax1:center)->(ax1:left)"``.
 
 You will also need to understand the `concept of "core dims"`_ used in ``xarray.apply_ufunc``.
 

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -143,15 +143,15 @@ Alternatively you can permanently turn a numpy function into a grid ufunc by usi
     from xgcm import as_grid_ufunc
 
     @as_grid_ufunc(signature="(ax1:center)->(ax1:left)")
-    def diff_forward(a):
-        return a - np.roll(a, -1, axis=-1)
+    def diff_center_to_left(a):
+        return diff_forward(a)
 
-Now when we call the ``diff_forward`` function, it will act as if we had applied it using ``apply_as_grid_ufunc``.
+Now when we call the ``diff_center_to_left`` function, it will act as if we had applied it using ``apply_as_grid_ufunc``.
 
 .. ipython:: python
     :okexcept:
 
-    diff_forward(grid, da, axis=[["X"]])
+    diff_center_to_left(grid, da, axis=[["X"]])
 
 Notice that we still need to provide the ``grid`` and ``axis`` arguments when we call the decorated function.
 
@@ -166,10 +166,10 @@ Finally you can use type hints to specify the grid positions of the variables in
     from xgcm import Gridded
 
     @as_grid_ufunc()
-    def diff_forward(
+    def diff_center_to_left(
         a: Gridded[np.ndarray, "ax1:center"]
     ) -> Gridded[np.ndarray, "ax1:left"]:
-        return a - np.roll(a, -1, axis=-1)
+        return diff_forward(a)
 
 .. note::
 
@@ -180,7 +180,7 @@ Again we call this decorated function, remembering to supply the grid and axis a
 .. ipython:: python
     :okexcept:
 
-    diff_forward(grid, da, axis=[["X"]])
+    diff_center_to_left(grid, da, axis=[["X"]])
 
 The signature argument is incompatible with using ``Gridded`` to annotate the types of any of the function arguments - i.e. you cannot mix the signature approach with the type hinting approach.
 
@@ -244,7 +244,6 @@ We can also see that the result depends on the choice of boundary conditions.
 
 Automatically Applying Boundary Conditions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 
 - ``boundary_width``
 - Relationship to padding

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -20,6 +20,8 @@ then here is a quick primer.
 
     Content about numpy...
 
+You will also need to understand the `concept of "core dims"`_ used in ``xarray.apply_ufunc``.
+
 Grid ufuncs allow us to:
 
 - Avoid mistakes by stating that functions are only valid for data on specific grid positions,
@@ -28,6 +30,7 @@ Grid ufuncs allow us to:
 - Immediately parallelize our operations with dask (see :ref:`Parallelizing with Dask`).
 
 .. _numpy generalized universal function: https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html
+.. _concept of "core dims": https://xarray.pydata.org/en/stable/generated/xarray.apply_ufunc.html
 
 The ``signature``
 ~~~~~~~~~~~~~~~~~
@@ -65,7 +68,6 @@ Lets imagine we have a numpy function which does forward differencing along one 
 .. ipython:: python
 
     import numpy as np
-
 
     def diff_forward(a):
         return a - np.roll(a, -1, axis=-1)
@@ -150,7 +152,6 @@ Alternatively you can permanently turn a numpy function into a grid ufunc by usi
 
     from xgcm import as_grid_ufunc
 
-
     @as_grid_ufunc(signature="(ax1:center)->(ax1:left)")
     def diff_center_to_left(a):
         return diff_forward(a)
@@ -172,18 +173,13 @@ Finally you can use type hints to specify the grid positions of the variables in
 .. ipython:: python
     :okexcept:
 
-    from xgcm import Gridded
-
+    from typing import Annotated
 
     @as_grid_ufunc()
     def diff_center_to_left(
-        a: Gridded[np.ndarray, "ax1:center"]
-    ) -> Gridded[np.ndarray, "ax1:left"]:
+        a: Annotated[np.ndarray, "ax1:center"]
+    ) -> Annotated[np.ndarray, "ax1:left"]:
         return diff_forward(a)
-
-.. note::
-
-    ``Gridded`` here is really just an alias for ``typing.Annotated``.
 
 Again we call this decorated function, remembering to supply the grid and axis arguments
 
@@ -192,13 +188,13 @@ Again we call this decorated function, remembering to supply the grid and axis a
 
     diff_center_to_left(grid, da, axis=[["X"]])
 
-The signature argument is incompatible with using ``Gridded`` to annotate the types of any of the function arguments
+The signature argument is incompatible with using ``Annotated`` to annotate the types of any of the function arguments
 - i.e. you cannot mix the signature approach with the type hinting approach.
 
 .. note::
 
     If you want to use type hints to specify a signature with multiple return arguments, your return value should be type hinted as a tuple of annotated hints, e.g.
-    ``Tuple[Gridded[np.ndarray, "ax1:left"], Gridded[np.ndarray, "ax1:right"]]``.
+    ``Tuple[Annotated[np.ndarray, "ax1:left"], Annotated[np.ndarray, "ax1:right"]]``.
 
 Boundaries and Padding
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -6,8 +6,22 @@ Grid Ufuncs
 Concept of a Grid Ufunc
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-- Generalisation of numpy generalized ufuncs to include axis positions of input and output variables
-- Primer on numpy generalized ufuncs
+In short, a "grid ufunc" is a generalisation of a `numpy generalized universal function`_ to include the xGCM Axes and Positions of input and output variables.
+We tell a function about the axes information through a ``signature``, which for a function which accepts data located at the center grid positions and returns data located on the same axis but now at the left-hand grid positions, would look like
+``"(Ax1:center)->(Ax1:left)"``.
+
+If you are not already familiar with numpy generalised universal functions (hereon referred to as "numpy ufuncs"), then here is a quick primer.
+
+- Primer on numpy generalized ufuncs (dropdown)
+
+Grid ufuncs allow us to:
+
+- Avoid mistakes by stating that functions are only valid for data on specific grid positions,
+- Neatly promote numpy functions to grid-aware xarray functions,
+- Conveniently apply boundary conditions and grid topologies (see :ref:`Boundaries and Padding`),
+- Immediately parallelize our operations with dask (see :ref:`Parallelizing with Dask`).
+
+.. _numpy generalized universal function: https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html
 
 Specifying the ``signature``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -34,10 +48,13 @@ A Simple Example
 - Something with an axis?
 - Mean
 
+.. _Boundaries and Padding:
+
 Boundaries and Padding
 ~~~~~~~~~~~~~~~~~~~~~~
 
-- ``boundary_widths``
+- ``boundary_width``
+- Relationship to padding
 - ``boundary``
 - 1D forward differencing?
 - Link to more specific docs?
@@ -48,6 +65,8 @@ Metrics
 
 - Specifying metrics
 - An example
+
+.. _Parallelizing with Dask:
 
 Parallelizing with Dask
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -64,7 +83,8 @@ Parallelizing Along Core Dimensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - We also optionally call ``dask.map_blocks``
-- Primer on ``dask.map_blocks``
-- The ``map_blocks`` kwarg
+- Primer on ``dask.map_overlap``
+- The ``map_overlap`` kwarg
+- Restriction that you can't do this with grid ufuncs that change length (e.g. center to outer)
 - Rechunking that occurs when padding?
 - Showing off the dask graph

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -29,6 +29,7 @@ Grid ufuncs allow us to:
 - Avoid mistakes by stating that functions are only valid for data on specific grid positions,
 - Neatly promote numpy functions to grid-aware xarray functions,
 - Conveniently apply boundary conditions and grid topologies (see :ref:`Boundaries and Padding`),
+- Boost performance relative to chaining many `Grid.diff` or `Grid.interp` operations,
 - Immediately parallelize our operations with dask (see :ref:`Parallelizing with Dask`).
 
 .. _numpy generalized universal function: https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -193,6 +193,8 @@ Alternatively you can permanently turn a numpy function into a grid ufunc by usi
 
     from xgcm import as_grid_ufunc
 
+.. ipython:: python
+
     @as_grid_ufunc(signature="(ax1:center)->(ax1:left)")
     def diff_center_to_left(a):
         return diff_forward(a)
@@ -200,7 +202,6 @@ Alternatively you can permanently turn a numpy function into a grid ufunc by usi
 Now when we call the ``diff_center_to_left`` function, it will act as if we had applied it using ``apply_as_grid_ufunc``.
 
 .. ipython:: python
-    :okexcept:
 
     diff_center_to_left(grid, da, axis=[["X"]])
 
@@ -212,7 +213,6 @@ Decorator with type hints
 Finally you can use type hints to specify the grid positions of the variables instead of passing a ``signature`` argument.
 
 .. ipython:: python
-    :okexcept:
 
     from typing import Annotated
 
@@ -258,7 +258,7 @@ This function simply averages each element from the one on its right, but that m
 
 .. ipython:: python
 
-    arr = np.arange(10)
+    arr = np.arange(9)
     arr
     arr.shape
 
@@ -313,19 +313,37 @@ before applying the operation in the function we decorated.
 .. ipython:: python
     :okexcept:
 
-    da = xr.DataArray(arr)
+    # Create new test data with same coordinates but linearly-spaced data
+    da = da.copy(data=arr)
 
     interp_center_to_left(grid, da, axis=[["X"]])
 
-It's used a periodic boundary condition as the default, but we can choose other boundary conditions using the ``boundary`` kwarg:
+Here a periodic boundary condition has been used as the default, but we can choose other boundary conditions using the ``boundary`` kwarg:
+
+.. ipython:: python
+    :okexcept:
+
+    @as_grid_ufunc(
+        signature="(X:center)->(X:left)",
+        boundary_width={"X": (1, 0)},
+        boundary="constant",
+        fill_value=0,
+    )
+    def interp_center_to_left_fill_with_zeros(a):
+        return interp(a)
+
+    interp_center_to_left_fill_with_zeros(
+        grid, da, axis=[["X"]], boundary="constant", fill_value=0
+    )
+
+We can also choose a different default boundary condition at decorator definition time,
+and then override it at function call time if we prefer.
 
 .. ipython:: python
     :okexcept:
 
     interp_center_to_left(grid, da, axis=[["X"]], boundary="constant", fill_value=0)
 
-We can also choose a different default boundary condition at decorator definition time,
-and then override it at function call time if we prefer.
 
 - Link to more specific docs?
 - Link to more complex examples?
@@ -340,6 +358,8 @@ Metrics
 
 Parallelizing with Dask
 ~~~~~~~~~~~~~~~~~~~~~~~
+
+
 
 Parallelizing Along Broadcast Dimensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -100,8 +100,12 @@ To give you an idea of how we might use grid ufuncs here is a table of possible 
 
 .. note::
 
-    Remember the axis names in the signature are dummy names - you could apply ``mean_depth`` along an axis not called
-    ``"depth"`` if you wish.
+    Remember the axis names in the signature are dummy names - in the example above you could apply ``mean_depth`` along
+    an axis not called ``"depth"`` if you wish.
+
+    The ``axis`` argument is the one which must correspond to an ``xgcm.Axis`` of the grid.
+    Therefore applying a grid ufunc with signature ``"(X:center)->()"`` or ``"(depth:center)->()"`` along ``axis='X'`` will
+    yield identical results in both cases.
 
 
 Defining New Grid Ufuncs

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -326,14 +326,14 @@ Here a periodic boundary condition has been used as the default, but we can choo
     @as_grid_ufunc(
         signature="(X:center)->(X:left)",
         boundary_width={"X": (1, 0)},
-        boundary="constant",
+        boundary="fill",
         fill_value=0,
     )
     def interp_center_to_left_fill_with_zeros(a):
         return interp(a)
 
     interp_center_to_left_fill_with_zeros(
-        grid, da, axis=[["X"]], boundary="constant", fill_value=0
+        grid, da, axis=[["X"]], boundary="fill", fill_value=0
     )
 
 We can also choose a different default boundary condition at decorator definition time,
@@ -342,7 +342,7 @@ and then override it at function call time if we prefer.
 .. ipython:: python
     :okexcept:
 
-    interp_center_to_left(grid, da, axis=[["X"]], boundary="constant", fill_value=0)
+    interp_center_to_left(grid, da, axis=[["X"]], boundary="fill", fill_value=np.NaN)
 
 
 - Link to more specific docs?

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -12,7 +12,9 @@ We tell a function about the axes information through a ``signature``, which for
 
 If you are not already familiar with numpy generalised universal functions (hereon referred to as "numpy ufuncs"), then here is a quick primer.
 
-- Primer on numpy generalized ufuncs (dropdown)
+.. dropdown:: Primer on numpy generalized universal functions
+
+    Content about numpy...
 
 Grid ufuncs allow us to:
 

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -355,8 +355,11 @@ and then override it at function call time if we prefer.
 Metrics
 ~~~~~~~
 
-- Specifying metrics
-- An example
+.. note::
+
+    Supplying metrics directly to grid ufuncs is not yet implemented, but will be soon!
+    To work with metrics outside of grid ufuncs see the documentation page on metrics.
+
 
 .. _Parallelizing with Dask:
 

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -7,12 +7,13 @@ Concept of a Grid Ufunc
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 In short, a "grid ufunc" is a generalisation of a `numpy generalized universal function`_ to include the xGCM Axes and Positions of input and output variables.
-We tell a function about the axes information through a ``signature``, which for a function which accepts data located at the center grid positions and returns data located on the same axis but now at the left-hand grid positions, would look like
-``"(Ax1:center)->(Ax1:left)"``.
+We tell a function about the axes information through a ``signature``, which for a function which accepts data located at the center grid positions and returns data located on the same axis but now at the left-hand grid positions would look like:
+
+``"(ax1:center)->(ax1:left)"``.
 
 If you are not already familiar with numpy generalised universal functions (hereon referred to as "numpy ufuncs"), then here is a quick primer.
 
-.. dropdown:: Primer on numpy generalized universal functions
+.. dropdown:: **Primer on numpy generalized universal functions**
 
     Content about numpy...
 
@@ -25,23 +26,96 @@ Grid ufuncs allow us to:
 
 .. _numpy generalized universal function: https://numpy.org/doc/stable/reference/c-api/generalized-ufuncs.html
 
-Specifying the ``signature``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Meaning of the ``signature``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Syntax
-- Dummy indices and naming conventions
-- Some simple examples
-- Can't supply data as kwargs
+The "signature" of a grid ufunc is how we tell it which input and output variables should be on which axis positions.
+A simple example would be
+``"(ax1:center)->(ax1:left)"``
+
+The signature has two parts, one for the input variables, and one for the output variables.
+The output variables live on the right of the arrow (``->``).
+
+There needs to be one bracketed entry for each variable, so in this case the signature tells use that the function accepts one input data variable and returns one output data variable.
+(Functions which accept a data variable in the form of a keyword-only argument are not supported.)
+
+For each variable, the signature tells us the ``xgcm.Axis`` positions we require that variable to have, both before and after our grid ufunc is applied.
+This information is encoded in the format ``axis_name:position``.
+Each variable can be operated on along multiple axes, which are separated by a comma, e.g. ``(ax1:left, ax2:right)``.
+
+The axis names used in the signature are dummy names: they do not have to be the same as the axis names used in your ``Grid`` object.
+This allows you to write a grid ufunc that can accept axis with any name.
+Therefore the signature ``"(ax1:center)->(ax1:left)"`` means all of
+
+`"This function accepts one data variable, which is one-dimensional and lies on the center grid positions of its singular axis.
+After performing its numerical operation the single return value from this function will have been shifted onto the left-hand grid positions of the same axis."`
+
+- Some simple examples, in a table
 
 Defining New Grid Ufuncs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Syntax Choices
-^^^^^^^^^^^^^^
+Lets imagine we have a numpy function which does forward differencing along one dimension, with an implicit periodic boundary condition.
+::
 
-- Decorator with signature
-- Decorator with type hints
-- Applying directly
+    def diff_forward(a):
+        return a - np.roll(a, -1, axis=-1)
+
+All this function does is subtract each element of the given array from the element immediately to its right, with the ends of the array wrapped around in a periodic fashion.
+If we imagine this function acting on a variable located at the cell centers, our axis position diagram suggests that the result would lie on the left-hand cell edges.
+Therefore the signature of this function could be
+``"(ax1:center)->(ax1:left)"``.
+
+.. note::
+
+    XGCM assumes the function acts along the last axis of the numpy array, which is why we have specified ``axis=-1`` here.
+
+There are multiple options for how to use this numpy ufunc as a grid ufunc.
+
+Applying directly
+^^^^^^^^^^^^^^^^^
+
+The quickest option is to apply our function directly, using ``apply_as_grid_ufunc``
+::
+
+    from xgcm import apply_as_grid_ufunc
+
+    apply_as_grid_ufunc(grid, data, diff_forward, signature="(ax1:center)->(ax1:left)", axis=[["X"]])
+
+Here we have applied the grid ufunc to the data, along the axis ``"X"`` of the grid.
+The dummy axis name ``ax1`` gets substituted by ``"X"`` during the call, so this will fail if our data does not depend on the axis we attempt to apply the ufunc along.
+
+Decorator with signature
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Alternatively you can permanently turn a numpy function into a grid ufunc by using the ``@as_grid_ufunc`` decorator.
+::
+
+    from xgcm import as_grid_ufunc
+
+    @as_grid_ufunc(signature="(ax1:center)->(ax1:left)")
+    def diff_forward(a):
+        return a - np.roll(a, -1, axis=-1)
+
+Now when we call the ``diff_forward`` function, it will act as if we had applied it using ``apply_as_grid_ufunc``.
+
+Decorator with type hints
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Finally you can use type hints to specify the grid positions of the variables instead of passing a ``signature`` argument.
+::
+
+    from xgcm import Gridded
+
+    @as_grid_ufunc()
+    def diff_forward(a: Gridded[np.ndarray, ax1:center]) -> Gridded[np.ndarray, ax1:left]:
+        return a - np.roll(a, -1, axis=-1)
+
+.. note::
+
+    ``Gridded`` here is really just an alias for ``typing.Annotated``.
+
+The signature argument is incompatible with using ``Gridded`` to annotate the types of any of the function arguments - i.e. you cannot mix the signature approach with the type hinting approach.
 
 A Simple Example
 ^^^^^^^^^^^^^^^^

--- a/doc/grid_ufuncs.rst
+++ b/doc/grid_ufuncs.rst
@@ -225,7 +225,6 @@ Finally you can use type hints to specify the grid positions of the variables in
 Again we call this decorated function, remembering to supply the grid and axis arguments
 
 .. ipython:: python
-    :okexcept:
 
     diff_center_to_left(grid, da, axis=[["X"]])
 
@@ -311,7 +310,6 @@ Now when we run our decorated function `interp_center_to_left`, xgcm will automa
 before applying the operation in the function we decorated.
 
 .. ipython:: python
-    :okexcept:
 
     # Create new test data with same coordinates but linearly-spaced data
     da = da.copy(data=arr)
@@ -321,7 +319,6 @@ before applying the operation in the function we decorated.
 Here a periodic boundary condition has been used as the default, but we can choose other boundary conditions using the ``boundary`` kwarg:
 
 .. ipython:: python
-    :okexcept:
 
     @as_grid_ufunc(
         signature="(X:center)->(X:left)",

--- a/doc/grids.rst
+++ b/doc/grids.rst
@@ -283,39 +283,39 @@ interpolate or take differences along the axis. First we create some test data:
 
 .. ipython:: python
 
-    f = np.sin(ds.x_c * 2 * np.pi / 9)
-    print(f)
-    f.plot()
+    da = np.sin(ds.x_c * 2 * np.pi / 9)
+    print(da)
+    da.plot()
 
 We interpolate as follows:
 
 .. ipython:: python
 
-    f_interp = grid.interp(f, axis="X")
-    f_interp
+    da_interp = grid.interp(da, axis="X")
+    da_interp
 
 We see that the output is on the ``x_g`` points rather than the original ``xc``
 points.
 
 .. warning::
 
-    xgcm does not perform input validation to verify that ``f`` is
+    xgcm does not perform input validation to verify that ``da`` is
     compatible with ``grid``.
 
 The same position shift happens with a difference operation:
 
 .. ipython:: python
 
-    f_diff = grid.diff(f, axis="X")
-    f_diff
+    da_diff = grid.diff(da, axis="X")
+    da_diff
 
 We can reverse the difference operation by taking a cumsum:
 
 .. ipython:: python
 
-    grid.cumsum(f_diff, "X")
+    grid.cumsum(da_diff, "X")
 
-Which is approximately equal to the original ``f``, modulo the numerical errors
+Which is approximately equal to the original ``da``, modulo the numerical errors
 accrued due to the discretization of the data.
 
 By default, these grid operations will drop any coordinate that are not
@@ -324,10 +324,10 @@ For example:
 
 .. ipython:: python
 
-    f2 = f + xr.Dataset(coords={"y": np.arange(1, 3)})["y"]
-    f2 = f2.assign_coords(h=f2.y ** 2)
-    print(f2)
-    grid.interp(f2, "X", keep_coords=True)
+    da2 = da + xr.Dataset(coords={"y": np.arange(1, 3)})["y"]
+    da2 = da2.assign_coords(h=da2.y ** 2)
+    print(da2)
+    grid.interp(da2, "X", keep_coords=True)
 
 So far we have just discussed simple grids (i.e. regular grids with a single
 face).

--- a/doc/grids.rst
+++ b/doc/grids.rst
@@ -61,6 +61,8 @@ The inverse of differentiation is integration. For finite volume grids, the
 inverse of the difference operator is a discrete cumulative sum. xgcm also
 provides a grid-aware version of the ``cumsum`` operator.
 
+.. _axis-positions:
+
 Axes and Positions
 ~~~~~~~~~~~~~~~~~~
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -46,6 +46,7 @@ Contents
    grid_topology
    grid_metrics
    grid_ufuncs
+   ufunc_examples
    transform
    xgcm-examples/02_mitgcm
    xgcm-examples/01_eccov4

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,6 +45,7 @@ Contents
    grids
    grid_topology
    grid_metrics
+   grid_ufuncs
    transform
    xgcm-examples/02_mitgcm
    xgcm-examples/01_eccov4

--- a/doc/ufunc_examples.rst
+++ b/doc/ufunc_examples.rst
@@ -21,28 +21,28 @@ Firstly we need a two-dimensional grid, and we use similar coordinate names to t
                 [
                     "x_c",
                 ],
-                np.arange(1, 10),
+                np.arange(1, 20),
                 {"axis": "X"},
             ),
             "x_g": (
                 [
                     "x_g",
                 ],
-                np.arange(0.5, 9),
+                np.arange(0.5, 19),
                 {"axis": "X", "c_grid_axis_shift": -0.5},
             ),
             "y_c": (
                 [
                     "y_c",
                 ],
-                np.arange(1, 10),
+                np.arange(1, 20),
                 {"axis": "Y"},
             ),
             "y_g": (
                 [
                     "y_g",
                 ],
-                np.arange(0.5, 9),
+                np.arange(0.5, 19),
                 {"axis": "Y", "c_grid_axis_shift": -0.5},
             ),
         }
@@ -69,8 +69,8 @@ We will create a 2D vector field, with components ``U`` and ``V``.
 
 .. ipython:: python
 
-    U = np.sin(grid_ds.y_c * 2 * np.pi / 9).expand_dims(x_c=9)
-    V = np.sin(grid_ds.x_c * 2 * np.pi / 9).expand_dims(y_c=9)
+    U = np.sin(grid_ds.x_c * 2 * np.pi / 19) * np.cos(grid_ds.y_c * 2 * np.pi / 19)
+    V = np.cos(grid_ds.x_c * 2 * np.pi / 19) * np.sin(grid_ds.y_c * 2 * np.pi / 19)
 
     ds = xr.Dataset({"V": V, "U": U})
     ds
@@ -123,7 +123,10 @@ Now we can compute the divergence of our example vector field
 
 .. ipython:: python
 
-    divergence(grid, ds['U'], ds['V'], axis=[('X', 'Y'), ('X', 'Y')])
+    div = divergence(grid, ds['U'], ds['V'], axis=[('X', 'Y'), ('X', 'Y')])
+
+    @savefig div_vector_field.png width=4in
+    div.plot(x='x_c')
 
 
 

--- a/doc/ufunc_examples.rst
+++ b/doc/ufunc_examples.rst
@@ -1,0 +1,88 @@
+.. _ufunc_examples:
+
+Ufunc Examples
+--------------
+
+This page contains examples of different Grid Ufuncs that you might find useful.
+They are intended to be more advanced or realistic cases than the simple differencing operations we showed in the introduction to :ref:`grid_ufuncs`.
+
+As each of these cases is a vector calculus operator, we will demonstrate their use on an example two-dimensional vector field.
+
+Firstly we need a two-dimensional grid, and we use similar coordinate names to the 1D example we used when first introducing :ref:`grids`.
+
+.. ipython:: python
+
+    import numpy as np
+    import xarray as xr
+
+    ds = xr.Dataset(
+        coords={
+            "x_c": (
+                [
+                    "x_c",
+                ],
+                np.arange(1, 10),
+                {"axis": "X"},
+            ),
+            "x_g": (
+                [
+                    "x_g",
+                ],
+                np.arange(0.5, 9),
+                {"axis": "X", "c_grid_axis_shift": -0.5},
+            ),
+            "y_c": (
+                [
+                    "y_c",
+                ],
+                np.arange(1, 10),
+                {"axis": "Y"},
+            ),
+            "y_g": (
+                [
+                    "y_g",
+                ],
+                np.arange(0.5, 9),
+                {"axis": "Y", "c_grid_axis_shift": -0.5},
+            ),
+        }
+    )
+    ds
+
+
+.. ipython:: python
+
+    from xgcm import Grid
+
+    grid = Grid(
+        ds,
+        coords={
+            "X": {"center": "x_c", "left": "x_g"},
+            "Y": {"center": "y_c", "left": "y_g"},
+        },
+    )
+    grid
+
+
+Divergence
+~~~~~~~~~~
+
+In two dimensions, the divergence operator accepts two vector components and returns one scalar result
+
+
+
+
+Gradient
+~~~~~~~~
+
+The gradient is almost like the opposite of divergence in the sense that it accepts one scalar and returns multiple vectors
+
+
+
+Curl/Vorticity
+~~~~~~~~~~~~~~
+
+
+
+Advection
+~~~~~~~~~

--- a/doc/ufunc_examples.rst
+++ b/doc/ufunc_examples.rst
@@ -15,7 +15,7 @@ Firstly we need a two-dimensional grid, and we use similar coordinate names to t
     import numpy as np
     import xarray as xr
 
-    ds = xr.Dataset(
+    grid_ds = xr.Dataset(
         coords={
             "x_c": (
                 [
@@ -47,7 +47,7 @@ Firstly we need a two-dimensional grid, and we use similar coordinate names to t
             ),
         }
     )
-    ds
+    grid_ds
 
 
 .. ipython:: python
@@ -55,13 +55,33 @@ Firstly we need a two-dimensional grid, and we use similar coordinate names to t
     from xgcm import Grid
 
     grid = Grid(
-        ds,
+        grid_ds,
         coords={
             "X": {"center": "x_c", "left": "x_g"},
             "Y": {"center": "y_c", "left": "y_g"},
         },
     )
     grid
+
+
+Now we need some data.
+We will create a 2D vector field, with components ``U`` and ``V``.
+
+.. ipython:: python
+
+    U = np.sin(grid_ds.y_c * 2 * np.pi / 9).expand_dims(x_c=9)
+    V = np.sin(grid_ds.x_c * 2 * np.pi / 9).expand_dims(y_c=9)
+
+    ds = xr.Dataset({"V": V, "U": U})
+    ds
+
+
+.. ipython:: python
+
+    @savefig example_vector_field.png width=4in
+    ds.plot.quiver("x_c", "y_c", u="U", v="V")
+
+
 
 
 Divergence

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -572,7 +572,7 @@ class TestDaskOverlap:
             map_overlap=True,
         )
         def diff_outer_to_center(a):
-            """Mocking up a function which can only act on in-memory arrays, and requires no padding"""
+            """Mocking up a function which can only act on in-memory arrays, and requires padding"""
             if isinstance(a, np.ndarray):
                 return a[..., 1:] - a[..., :-1]
             else:


### PR DESCRIPTION
 - [x] Helps closs the "how-to" part of #423
 - [x] Passes `pre-commit run --all-files`

Builds on top of #431, adding more complicated examples of defining grid ufuncs, such as:
 - [x] divergence
 - [ ] gradient
 - [ ] curl
 - [ ] advection