### PR TITLE
Increase CI time limit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Build (${{ matrix.python-version }} | ${{ matrix.os }})
     if: github.repository == 'xgcm/xgcm'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
Should avoid periodic time out failures like [this](https://github.com/xgcm/xgcm/runs/6065092725?check_suite_focus=true).
