### PR TITLE
Include submodules in RTD

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,8 @@
 version: 2
 
+submodules:
+  include: all
+
 build:
   os: "ubuntu-20.04"
   tools:


### PR DESCRIPTION
An attempt to fix #424 by following the guidance on [RTD documentation](https://docs.readthedocs.io/en/stable/config-file/v2.html#submodules).

My suspicion is that https://github.com/xgcm/xgcm/pull/401 introduced this bug, but I unfortunately cannot verify this, since the builds are not retained that long on RTD...

We might want to consider to fail on warning to be aware of doc problems more directly?

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #424
 - [x] Passes `pre-commit run --all-files`