### PR TITLE
Improve error message around invalid axis shifts (and slight refactoring)

### DIFF
--- a/xgcm/comodo.py
+++ b/xgcm/comodo.py
@@ -1,5 +1,10 @@
 from collections import OrderedDict
 
+# Representation of axis shifts
+axis_shift_left  =  0.5
+axis_shift_right = -0.5
+# Characeterizes valid shifts only
+valid_axis_shifts = [axis_shift_left, axis_shift_right]
 
 def assert_valid_comodo(ds):
     """Verify that the dataset meets comodo conventions
@@ -102,7 +107,7 @@ def get_axis_positions_and_coords(ds, axis_name):
             axis_coords["outer"] = name
         elif clen == axis_len - 1:
             axis_coords["inner"] = name
-        elif shift == -0.5:
+        elif shift == axis_shift_left:
             if clen == axis_len:
                 axis_coords["left"] = name
             else:
@@ -110,7 +115,7 @@ def get_axis_positions_and_coords(ds, axis_name):
                     "Left coordinate %s has incompatible "
                     "length %g (axis_len=%g)" % (name, clen, axis_len)
                 )
-        elif shift == 0.5:
+        elif shift == axis_shift_right:
             if clen == axis_len:
                 axis_coords["right"] = name
             else:

--- a/xgcm/comodo.py
+++ b/xgcm/comodo.py
@@ -131,7 +131,7 @@ def get_axis_positions_and_coords(ds, axis_name):
                 raise ValueError(
                     "Coordinate %s has invalid "
                     "`c_grid_axis_shift` attribute `%s`. "
-                    "c_grid_axis_shift must be one of: %s" % (name, repr(shift), valids)
+                    "`c_grid_axis_shift` must be one of: %s" % (name, repr(shift), valids)
                 )
             else:
                 raise ValueError(

--- a/xgcm/comodo.py
+++ b/xgcm/comodo.py
@@ -124,12 +124,21 @@ def get_axis_positions_and_coords(ds, axis_name):
                     "length %g (axis_len=%g)" % (name, clen, axis_len)
                 )
         else:
-            raise ValueError(
-                "Coordinate %s has invalid or missing "
-                "`c_grid_axis_shift` attribute `%s`" % (name, repr(shift))
-            )
-    return axis_coords
+            if shift not in valid_axis_shifts:
+                # string representing of valid axis shifts
+                valids = str(valid_axis_shifts)[1:-1]
 
+                raise ValueError(
+                    "Coordinate %s has invalid "
+                    "`c_grid_axis_shift` attribute `%s`. "
+                    "c_grid_axis_shift must be one of: %s" % (name, repr(shift), valids)
+                )
+            else:
+                raise ValueError(
+                    "Coordinate %s has missing "
+                    "`c_grid_axis_shift` attribute `%s`" % (name, repr(shift))
+                )
+    return axis_coords
 
 def _assert_data_on_grid(da):
     pass

--- a/xgcm/comodo.py
+++ b/xgcm/comodo.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 # Representation of axis shifts
 axis_shift_left  =  0.5
 axis_shift_right = -0.5
-# Characeterizes valid shifts only
+# Characterize valid shifts only
 valid_axis_shifts = [axis_shift_left, axis_shift_right]
 
 def assert_valid_comodo(ds):

--- a/xgcm/comodo.py
+++ b/xgcm/comodo.py
@@ -125,7 +125,7 @@ def get_axis_positions_and_coords(ds, axis_name):
                 )
         else:
             if shift not in valid_axis_shifts:
-                # string representing of valid axis shifts
+                # string representing valid axis shifts
                 valids = str(valid_axis_shifts)[1:-1]
 
                 raise ValueError(


### PR DESCRIPTION
If an invalid axis shift is specified for `c_grid_axis_shift`, this change explains the correct range of values, e.g: given code

```
g = Grid(xr.Dataset(
        coords={
            "x_c": (
                ["x_c"],
                np.arange(1, 10),
                {"axis": "X"},
            ),
            "x_g": (
                ["x_g"],
                np.arange(0.5, 9),
                {"axis": "X", "c_grid_axis_shift": 1},
            ),
        }
    ))
```

The error is now

```
ValueError: Coordinate x_g has invalid `c_grid_axis_shift` attribute `1.0`. `c_grid_axis_shift` must be one of: 0.5, -0.5
```
I did some slight refactoring to the code around here to pull out number constants to the top level.