### PR TITLE
Use py3.10 for core-deps and upstream ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
         channel-priority: strict
         activate-environment: test_env_xgcm # Defined in ci/environment.yml
         auto-update-conda: false
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.10"
         environment-file: ci/environment-core-deps.yml
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
     - name: Set up conda environment
@@ -120,7 +120,7 @@ jobs:
         channel-priority: strict
         activate-environment: test_env_xgcm # Defined in ci/environment.yml
         auto-update-conda: false
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.10"
         environment-file: ci/environment-upstream-dev.yml
         use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
     - name: Set up conda environment

--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -13,6 +13,5 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - python=3.9
   - xarray
   - typing_extensions


### PR DESCRIPTION
This seems to have been a bug in the CI workflow.  Could potentially help with #502

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
