### PR TITLE
Replace `periodic` kwarg with an option in `padding`

### DIFF
--- a/xgcm/autogenerate.py
+++ b/xgcm/autogenerate.py
@@ -74,18 +74,17 @@ def generate_axis(
                             to be specified'
         )
 
+    # TODO 2022-08-10 raehik - deleted setting periodic var, default to
+    # periodic?
     if pad is None:
         fill_value = 0.0
-        boundary = None
-        periodic = True
+        boundary = "periodic"
     elif pad == "auto":
         fill_value = 0.0
         boundary = "extrapolate"
-        periodic = False
     else:
         fill_value = pad
         boundary = "fill"
-        periodic = False
 
     kwargs = dict(
         boundary_discontinuity=boundary_discontinuity,
@@ -112,7 +111,7 @@ def generate_axis(
         # or xgcm.Axis throws error. Will be rewrapped below.
         ds[name] = _fill_attrs(ds[name], "center", axis)
 
-        ax = Axis(ds, axis, periodic=periodic)
+        ax = Axis(ds, axis)
         args = ds[name], raw_interp_function, relative_pos_to
         ds.coords[new_name] = ax._neighbor_binary_func_raw(*args, **kwargs)
 
@@ -121,7 +120,7 @@ def generate_axis(
         ds[new_name] = _fill_attrs(ds[new_name], pos_to, axis)
     else:
         kwargs.pop("position_check", None)
-        ax = Axis(ds, axis, periodic=periodic)
+        ax = Axis(ds, axis)
         args = ds[name], pos_to
         ds.coords[new_name] = ax.interp(*args, **kwargs)
     return ds

--- a/xgcm/duck_array_ops.py
+++ b/xgcm/duck_array_ops.py
@@ -51,7 +51,7 @@ def _apply_boundary_condition(da, dim, left, boundary=None, fill_value=0.0):
     left : bool
         If `True`, boundary condition is at left (beginning of array).
         If `False`, boundary condition is at the right (end of the array).
-    boundary : {'fill', 'extend', 'extrapolate'}
+    boundary : {'fill', 'extend', 'extrapolate', 'periodic'}
         A flag indicating how the boundary values are determined.
 
         * 'fill':  All values outside the array set to fill_value
@@ -60,14 +60,16 @@ def _apply_boundary_condition(da, dim, left, boundary=None, fill_value=0.0):
           value. (i.e. a limited form of Neumann boundary condition.)
         * 'extrapolate': Set values by extrapolating linearly from the two
           points nearest to the edge
+        * 'periodic': TODO
     fill_value : float, optional
         The value to use in the boundary condition with `boundary='fill'`.
     """
 
-    if boundary not in ["fill", "extend", "extrapolate"]:
+    # TODO 2022-08-10 raehik - bad, also defined in grid.py
+    if boundary not in ["fill", "extend", "extrapolate", "periodic"]:
         raise ValueError(
-            "`boundary` must be 'fill', 'extend' or "
-            "'extrapolate', not %r." % boundary
+            "`boundary` must be 'fill', 'extend', 'extrapolate' or "
+            "'periodic', not %r." % boundary
         )
 
     axis_num = da.get_axis_num(dim)
@@ -82,6 +84,7 @@ def _apply_boundary_condition(da, dim, left, boundary=None, fill_value=0.0):
 
     use_dask = has_dask and isinstance(base_array, dsa.Array)
 
+    boundary_array = []
     if boundary == "extend":
         boundary_array = edge_array
     elif boundary == "fill":

--- a/xgcm/test/test_autogenerate.py
+++ b/xgcm/test/test_autogenerate.py
@@ -233,7 +233,7 @@ def test_generate_axis():
     assert_allclose(f["z_outer"], ds_out_outer["z_outer"])
     assert_allclose(g["lon_outer"], ds_out_outer["lon_outer"])
 
-    # Mulitdim cases
+    # Multidim cases
     aa = generate_axis(
         a,
         "X",

--- a/xgcm/test/test_faceconnections.py
+++ b/xgcm/test/test_faceconnections.py
@@ -128,7 +128,7 @@ def cubed_sphere_connections():
 
 def test_create_periodic_grid(ds):
     ds = ds.isel(face=0)
-    grid = Grid(ds, periodic=True)
+    grid = Grid(ds, boundary="periodic")
     for axis_name in grid.axes:
         axis = grid.axes[axis_name]
         assert axis._facedim is None
@@ -143,7 +143,7 @@ def test_create_periodic_grid(ds):
 
 def test_get_periodic_grid_edge(ds):
     ds = ds.isel(face=0)
-    grid = Grid(ds, periodic=True)
+    grid = Grid(ds, boundary="periodic")
 
     xaxis = grid.axes["X"]
     left_edge_data_x = xaxis._get_edge_data(ds.data_c)
@@ -180,7 +180,7 @@ def test_create_connected_grid(ds, ds_face_connections_x_to_x):
 
 def test_diff_interp_connected_grid_x_to_x(ds, ds_face_connections_x_to_x):
     # simplest scenario with one face connection
-    grid = Grid(ds, face_connections=ds_face_connections_x_to_x, periodic=False)
+    grid = Grid(ds, face_connections=ds_face_connections_x_to_x)
     diff_x = grid.diff(ds.data_c, "X", boundary="fill")
     interp_x = grid.interp(ds.data_c, "X", boundary="fill")
 
@@ -227,9 +227,7 @@ def test_vector_connected_grid_x_to_y(ds, ds_face_connections_x_to_y, boundary):
         face_connections=ds_face_connections_x_to_y,
         boundary=boundary,
         fill_value=1,
-        periodic=False,
     )
-    # TODO: Remove the periodic once that is deprecated.
     # ! Set boundary on grid, so it is applied to all axes.
     # TODO: modify the non velocity tests too (after release)
 


### PR DESCRIPTION
(Note that `padding` is the intended updated name for `boundary` -- that change isn't (for now?) covered in this PR.)

Related issues:

  * https://github.com/xgcm/xgcm/issues/195
  * https://github.com/xgcm/xgcm/issues/509
  * overview issue https://github.com/xgcm/xgcm/issues/414

<!--
Feel free to remove check-list items aren't relevant to your change

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
-->