### PR TITLE
require ipython version which fixes decorator issue

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - matplotlib
   - sphinx_rtd_theme
   - ipykernel
+  - ipython>=8.5.0
 #  - python-graphviz
   - pip:
     - nbsphinx
@@ -22,4 +23,3 @@ dependencies:
     - sphinx-copybutton
     - sphinxcontrib-srclinks
     - sphinx-panels
-    - git+https://github.com/ipython/ipython.git


### PR DESCRIPTION
Ipython finally released a new version, which means we no longer have to pin our docs build to their master branch in order to fix #455.

 - [x] Closes #455