### PR TITLE
Fix gh518 bug

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -17,6 +17,9 @@ Breaking Changes
 Internal Changes
 ~~~~~~~~~~~~~~~~
 
+- Rewrote cumsum to use a different code path from :py:func:`~xgcm.apply_as_grid_ufunc` internally,
+  which makes it less susceptible to subtle bugs like the one reported in :issue:`507`. (:pull:`558`).
+  By `Thomas Nicholas <https://github.com/tomnicholas>`_.
 
 Documentation
 ~~~~~~~~~~~~~

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -24,6 +24,9 @@ Documentation
 Bugfixes
 ~~~~~~~~
 
+- Fix bug where chunked core dims of only a single chunk triggered errors. (:pull:`558`, :issue:`518`, :issue:`522`)
+  By `Thomas Nicholas <https://github.com/tomnicholas>`_.
+
 
 v0.8.0 (2022/06/14)
 -------------------

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -2311,7 +2311,7 @@ class Grid:
 
         return _reattach_coords(
             [data], grid=self, boundary_width=boundary_width, keep_coords=True
-        )
+        )[0]
 
     def _apply_vector_function(self, function, vector, **kwargs):
         if not (len(vector) == 2 and isinstance(vector, dict)):

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -2208,6 +2208,7 @@ class Grid:
         boundary=None,
         fill_value=None,
         metric_weighted=None,
+        keep_coords: bool = False,
     ) -> xr.DataArray:
         """
         Cumulatively sum a DataArray, transforming to the intermediate axis
@@ -2331,7 +2332,7 @@ class Grid:
                 [coordless],
                 grid=self,
                 boundary_width=ax_boundary_width,
-                keep_coords=True,
+                keep_coords=keep_coords,
             )[0]
 
             ax_metric_weighted = metric_weighted[ax.name]

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -2253,6 +2253,7 @@ class Grid:
         """
 
         boundary_width = {}
+        old_to_new_dims = {}
 
         if isinstance(axis, str):
             axis = [axis]
@@ -2269,6 +2270,10 @@ class Grid:
             ax_to = to[ax.name]
             if ax_to is None:
                 ax_to = ax._default_shifts[pos]
+
+            # get dim with position to
+            new_dim_name = ax.coords[ax_to]
+            old_to_new_dims[dim] = new_dim_name
 
             # now pad / trim the data as necessary
             # here we enumerate all the valid possible shifts
@@ -2307,10 +2312,13 @@ class Grid:
             fill_value=fill_value,
         )
 
-        # TODO need to rename dims to their new positions here for this to work
+        renamed = data.rename(old_to_new_dims)
+
+        # drop all coords to avoid conflicts when attaching new ones
+        renamed = renamed.drop(renamed.coords)
 
         return _reattach_coords(
-            [data], grid=self, boundary_width=boundary_width, keep_coords=True
+            [renamed], grid=self, boundary_width=boundary_width, keep_coords=True
         )[0]
 
     def _apply_vector_function(self, function, vector, **kwargs):

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -909,7 +909,7 @@ def _pad_then_rechunk(
 
 def _is_dim_chunked(a, dim):
     # TODO this func can't handle Datasets - it will error if you check multiple variables with different chunking
-    return len(a.variable.chunksizes[dim]) > 0
+    return len(a.variable.chunksizes[dim]) > 1
 
 
 def _has_chunked_core_dims(obj: xr.DataArray, core_dims: Sequence[str]) -> bool:

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -1111,7 +1111,7 @@ def _reattach_coords(
     results_with_coords = []
     for res in results:
 
-        # padding strips all coordinates (inlcuding dimension coordinates).
+        # padding strips all coordinates (including dimension coordinates).
         # Here we centrally restore them from the grid._ds.
         all_matching_coords = {
             coord: da_coord

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -829,13 +829,14 @@ class TestPadAfterUFunc:
         )
         assert_equal(result, expected)
 
-    def test_cumsum_chunk_checking_bug(self):
-        # see issue #507
+    @pytest.mark.parametrize("chunksize", [-1, 3])
+    def test_cumsum_chunk_checking_bug(self, chunksize):
+        # for chunksize=-1 see issue #507
         ds = (
             xr.DataArray(
                 np.ones(10) * 0.5, dims="Z", coords={"Z": np.arange(0.5, 10, 1)}
             )
-            .chunk({"Z": -1})
+            .chunk({"Z": chunksize})
             .to_dataset(name="drF")
         )
         ds.coords["Zp1"] = xr.DataArray(
@@ -845,9 +846,6 @@ class TestPadAfterUFunc:
 
         grid.cumsum(ds.drF, "Z", boundary="periodic")
         grid.cumsum(ds.drF, "Z", boundary="extend")
-
-    def test_cumsum_chunked_core_dim(self):
-        ...
 
 
 class TestDaskNoOverlap:

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -846,6 +846,9 @@ class TestPadAfterUFunc:
         grid.cumsum(ds.drF, "Z", boundary="periodic")
         grid.cumsum(ds.drF, "Z", boundary="extend")
 
+    def test_cumsum_chunked_core_dim(self):
+        ...
+
 
 class TestDaskNoOverlap:
     def test_chunked_non_core_dims(self):

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -1110,6 +1110,32 @@ class TestMapOverlapGridops:
         result = grid.diff(da, axis="depth", to="right").compute()
         assert_equal(result, expected)
 
+    def test_single_chunk_core_dims_center_to_outer(self):
+        # test for issue #518
+        z_coord = xr.DataArray(np.arange(0.5, 10, 1), dims="Z")
+        zp1_coord = xr.DataArray(np.arange(11), dims="Zp1")
+        ds = (
+            xr.DataArray(np.linspace(1, 10, num=10), dims="Z", coords={"Z": z_coord})
+            .chunk({"Z": -1})
+            .to_dataset(name="drF")
+        )
+        ds.coords["Zp1"] = zp1_coord
+        grid = Grid(ds, coords={"Z": {"center": "Z", "outer": "Zp1"}})
+
+        expected_values = np.concatenate(
+            (np.array([1.0]), np.linspace(1.5, 9.5, num=9), np.array([10.0]))
+        )
+        expected = (
+            xr.DataArray(expected_values, dims="Zp1", coords={"Zp1": zp1_coord})
+            .chunk({"Zp1": -1})
+            .to_dataset(name="drF")
+        )
+
+        result = grid.interp(ds.drF, "Z", boundary="extend", to="outer").to_dataset(
+            name="drF"
+        )
+        assert_equal(result, expected)
+
 
 class TestSignaturesEquivalent:
     def test_equivalent(self):


### PR DESCRIPTION
This fixes the bug reported in #518 and #522 (by undoing a regression introduced in #515).

Unfortunately this fix breaks `cumsum` in some cases (specifically the test `xgcm/test/test_grid_ufunc.py::TestPadAfterUFunc::test_cumsum_chunk_checking_bug` now fails on this branch). The way it breaks cumsum is pretty subtle and I think I will fix that in a complementary second PR.

EDIT: Fixing cumsum in this PR

 - [x] Closes #518
 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
