### PR TITLE
Add check for print statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-yaml
   - repo: https://github.com/dhruvmanila/remove-print-statements
     rev: v0.5.0
-      hooks:
+    hooks:
       - id: remove-print-statements
         args: ['--verbose']   # Show all the print statements to be removed
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     rev: v0.5.0
     hooks:
       - id: remove-print-statements
+        files: 'xgcm'
         args: ['--verbose']   # Show all the print statements to be removed
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,11 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+  - repo: https://github.com/dhruvmanila/remove-print-statements
+    rev: 'v0.5.0'
+      hooks:
+      - id: remove-print-statements
+        args: ['--verbose']   # Show all the print statements to be removed
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
   - repo: https://github.com/dhruvmanila/remove-print-statements
-    rev: 'v0.5.0'
+    rev: v0.5.0
       hooks:
       - id: remove-print-statements
         args: ['--verbose']   # Show all the print statements to be removed

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,16 @@ import sys
 
 import xgcm
 
+# If extensions (or modules to document with autodoc) are in another directory,
+ # add these directories to sys.path here. If the directory is relative to the
+ # documentation root, use os.path.abspath to make it absolute, like shown here.
+ # sys.path.insert(0, os.path.abspath('.'))
+ # sys.path.insert(os.path.abspath('..'))
+
+ print("python exec:", sys.executable)
+ print("sys.path:", sys.path)
+
+
 
 # -- General configuration ------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,15 +19,6 @@ import sys
 
 import xgcm
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, os.path.abspath('.'))
-# sys.path.insert(os.path.abspath('..'))
-
-print("python exec:", sys.executable)
-print("sys.path:", sys.path)
-
 
 # -- General configuration ------------------------------------------------
 

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -141,10 +141,6 @@ class Grid:
         # Default is to do this to preserve backwards compatability
         if autoparse_metadata:
             ds, parsed_kwargs = metadata_parsers.parse_metadata(ds)
-
-            # Loop over input kwargs. If None and parsed alternative available
-            # then replace local variable with autoparsed. If conflict raise error.
-            print(f"coords = {coords}")
             duplicates = []
             if "coords" in parsed_kwargs:
                 if coords is None:

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -201,8 +201,6 @@ class TestParseSignatureFromTypeHints:
         # This should raise a mypy error, which is then ignored
         @as_grid_ufunc()
         def ufunc1(a: Annotated[str, "X:center"]) -> Annotated[np.ndarray, "X:center"]:
-            # np.ndarray has a .strides method but str doesn't (and nor does xr.DataArray)
-            print(a.strides)  # type: ignore
             return a  # type: ignore
 
         # This should pass mypy without raising any errors
@@ -210,7 +208,6 @@ class TestParseSignatureFromTypeHints:
         def ufunc3(
             a: Annotated[np.ndarray, "X:center"]
         ) -> Annotated[np.ndarray, "X:center"]:
-            print(a.strides)
             return a
 
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Just found a [leftover print statement](https://github.com/xgcm/xgcm/blob/8fcd0b062f80355bce8bf10d5ecda6b2587138e4/xgcm/grid.py#L147) from #551. 

Lets implement a linter to prevent this in the future.

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
