### PR TITLE
Add Tests for vector input

### DIFF
--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -609,7 +609,8 @@ class TestGridUFuncNoPadding:
 
 
 class TestGridUfuncWithPadding:
-    def test_1d_padded_but_no_change_in_grid_position(self):
+    @pytest.mark.parametrize("vector", [True, False])
+    def test_1d_padded_but_no_change_in_grid_position(self, vector):
         def diff_center_to_center_second_order(a):
             return 0.5 * (a[..., 2:] - a[..., :-2])
 
@@ -621,6 +622,10 @@ class TestGridUfuncWithPadding:
         expected = xr.DataArray(
             diffed, dims=["depth_c"], coords={"depth_c": grid._ds.depth_c}
         )
+
+        # # wrap dataarray in vector syntax
+        if vector:
+            da = {"depth": da}
 
         # Test direct application
         result = apply_as_grid_ufunc(


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Towards #581
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`

---

Tom: Suggested code improvements to prevent lots of bugs like this occurring:
- Properly type hint all places where a vector could be passed,
- Use the `typing` module's `@overload` decorator to type hint functions in an unambiguous way (i.e. scalar->scalar & vector->vector, but not vector->scalar),
- Type hinting `pad` and its internals is the most important part, because that's the only place that vectors are treated meaningfully differently,
- Other cases could potentially be handled by a `@handle_vectors` decorator wrapping methods, that unpacks, calls method, then re-wraps.
- Test padding dask arrays in functions like `diff_vector_2d`,
- Add an `is_vector` flag to any test dataset factory created (see #https://github.com/xgcm/xgcm/issues/466#issuecomment-1382451003)
