### PR TITLE
Deprecate `periodic` input ...

### DIFF
--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -576,9 +576,7 @@ class Grid:
     def __repr__(self):
         summary = ["<xgcm.Grid>"]
         for name, axis in self.axes.items():
-            summary.append(
-                "%s Axis (boundary=%r):" % (name, axis.boundary)
-            )
+            summary.append("%s Axis (boundary=%r):" % (name, axis.boundary))
             summary += axis._coord_desc()
         return "\n".join(summary)
 
@@ -873,7 +871,7 @@ class Grid:
         if a global 2D dataset should be interpolated on both X and Y axis, but it is
         only periodic in the X axis (and should be padded along the Y axis), we can do this:
 
-        >>> grid.interp(da, ["X", "Y"], boundary={"X": 'periodic', "Y": 'fill'})
+        >>> grid.interp(da, ["X", "Y"], boundary={"X": "periodic", "Y": "fill"})
         """
         return self._1d_grid_ufunc_dispatch("interp", da, axis, **kwargs)
 


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->
This is my attempt to resolve a bunch of issues that stem from the fact that we still support `periodic` as input. This should stop right here. 

This is a reimplementation of #534 which is quite far behind at this point (my apologies to the original author for falling behind on the maintainer duties here). 

Totally just taking a first stab here to give people a point of reference. This needs some careful (not past 9pm) consideration of how to change the tests. The fact that periodic is so deeply embedded into the test suite is really the reason that it was not removed earlier. 

 - [ ] Closes #195,#509, #604, #624, #625
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
