### PR TITLE
Update grid_ufunc.py

### DIFF
--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -1022,8 +1022,10 @@ def _rechunk_to_merge_in_boundary_chunks(
     rechunked_padded_args = []
     for padded_arg, original_arg in zip(padded_args, original_args):
         # I find 'original_arg' is a dict and will get error if directly use 'original_arg.variables'
-        original_arg_chunks = original_arg[list(original_arg.keys())[0]].variable.chunksizes
-        
+        original_arg_chunks = original_arg[
+            list(original_arg.keys())[0]
+        ].variable.chunksizes
+
         merged_boundary_chunks = _get_chunk_pattern_for_merging_boundary(
             grid,
             padded_arg,

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -1021,7 +1021,9 @@ def _rechunk_to_merge_in_boundary_chunks(
 
     rechunked_padded_args = []
     for padded_arg, original_arg in zip(padded_args, original_args):
-        original_arg_chunks = original_arg.variable.chunksizes
+        # I find 'original_arg' is a dict and will get error if directly use 'original_arg.variables'
+        original_arg_chunks = original_arg[list(original_arg.keys())[0]].variable.chunksizes
+        
         merged_boundary_chunks = _get_chunk_pattern_for_merging_boundary(
             grid,
             padded_arg,


### PR DESCRIPTION
Hi all,

I just found a bug in the xgcm when calculating the vector from the native LLC grid. My xgcm version is 0.8.1 xarray 2024.2.0    After I fixed the bug, now the xgcm can work well.

Best,
Ran




<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [ ] Closes #xxxx
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
