### PR TITLE
Suppress warning about ``output_sizes`` parameter

### DIFF
--- a/xgcm/transform.py
+++ b/xgcm/transform.py
@@ -252,8 +252,8 @@ def conservative_interpolation(
         input_core_dims=[[phi_dim], [theta_dim], [target_dim]],
         output_core_dims=[["remapped"]],
         dask="parallelized",
+        dask_gufunc_kwargs = {'output_sizes':{"remapped": len(target_theta_levels) - 1}},
         # Since we are introducing a new dimension instead of changing it we need to declare the output size.
-        output_sizes={"remapped": len(target_theta_levels) - 1},
         output_dtypes=[phi.dtype],
     ).rename({"remapped": target_dim})
 

--- a/xgcm/transform.py
+++ b/xgcm/transform.py
@@ -252,7 +252,7 @@ def conservative_interpolation(
         input_core_dims=[[phi_dim], [theta_dim], [target_dim]],
         output_core_dims=[["remapped"]],
         dask="parallelized",
-        dask_gufunc_kwargs = {'output_sizes':{"remapped": len(target_theta_levels) - 1}},
+        dask_gufunc_kwargs={"output_sizes": {"remapped": len(target_theta_levels) - 1}},
         # Since we are introducing a new dimension instead of changing it we need to declare the output size.
         output_dtypes=[phi.dtype],
     ).rename({"remapped": target_dim})


### PR DESCRIPTION
Getting rid of
``` 
FutureWarning: ``output_sizes`` should be given in the ``dask_gufunc_kwargs`` parameter. It will be removed as direct parameter in a future version.
```
when calling .transform

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Passes `pre-commit run --all-files`
