### PR TITLE
Replace types-pkg-resources with types-setuptools in mypy pc hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         exclude: "properties|asv_bench|_typed_ops.py"
         additional_dependencies: [
             # Type stubs
-            types-pkg_resources,
+            types-setuptools,
             types-PyYAML,
             typing-extensions,
             # Dependencies that are typed


### PR DESCRIPTION
The Pre-commit CI [has been broken](https://results.pre-commit.ci/run/github/41581350/1722898419.79gnFiVaT4e4yaT14x-V4w) for a while now and it seems to be an issue with types-pkg-resources. I noticed that the package [was yanked](https://pypi.org/project/types-pkg-resources/), and will try here to implement the recommendations

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #643 
 - [x] Passes `pre-commit run --all-files`
