### PR TITLE
Implement axis directionality (in low-level ufuncs)

### DIFF
--- a/xgcm/gridops.py
+++ b/xgcm/gridops.py
@@ -15,7 +15,7 @@ through when `xgcm.Grid.diff()` is called. See xgcm.grid_ufunc._select_grid_ufun
 
 
 # TODO can we allow for grouping these definitions into classes? Similar to pytest tests?
-
+# TODO what is the best way to generalize the Diff and Cumsum ufuncs so that they have a sense of directionality?
 
 # Diff
 


### PR DESCRIPTION
This is an attempt to revive prior efforts to add a sense of directionality to xgcm grid axes, especially https://github.com/xgcm/xgcm/pull/338.

Unfortunately, @gmacgilchrist's prior attempt at this PR predated the ufunc-ification of grid operations (see PR https://github.com/xgcm/xgcm/pull/479 and the issue it closes https://github.com/xgcm/xgcm/issues/344), which meant that it eventually became stale and was closed.

 - [ ] Closes https://github.com/xgcm/xgcm/issues/337
 - [ ] Tests added
 - [ ] Passes `pre-commit run --all-files`
 - [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [ ] New functions/methods are listed in `api.rst`
