### PR TITLE
Rename boundary to padding across the codebase

### DIFF
--- a/xgcm/axis.py
+++ b/xgcm/axis.py
@@ -33,10 +33,11 @@ class Axis:
         default_shifts: Optional[
             Mapping[str, str]
         ] = None,  # TODO type hint as Literal of the allowed options
-        boundary: Optional[
+        padding: Optional[
             str
         ] = None,  # TODO type hint as Literal of the allowed options
         fill_value: Optional[float] = None,
+        **kwargs,
     ):
         """
         Create a new Axis object from an input dataset.
@@ -53,11 +54,11 @@ class Axis:
         default_shifts : dict, optional
             Default mapping from and to grid positions
             (e.g. `{'center': 'left'}`). Will be inferred if not specified.
-        boundary : {None, 'fill', 'extend', 'periodic'}, optional
-            A flag indicating how to handle boundaries:
+        padding : {None, 'fill', 'extend', 'periodic'}, optional
+            A flag indicating how to handle padding:
 
-            * None:  Do not apply any boundary conditions. Raise an error if
-              boundary conditions are required for the operation.
+            * None:  Do not apply any padding conditions. Raise an error if
+              padding conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
               (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
@@ -65,8 +66,14 @@ class Axis:
             * 'periodic': Set values by wrapping around the array on the specified
                 axes. (i.e. a periodic boundary condition.)
         fill_value : float, optional
-            The value to use in the boundary condition when boundary='fill'.
+            The value to use in the padding condition when padding='fill'.
         """
+        # TODO - remove deprecation handling
+        if "boundary" in kwargs:
+            raise ValueError(
+                "Argument 'boundary' has been renamed to 'padding'. "
+                "Please use 'padding' instead."
+            )
 
         if not isinstance(name, str):
             raise TypeError(
@@ -114,13 +121,13 @@ class Axis:
                     f"Can't set the default shift for {pos} to be to {pos}"
                 )
 
-        if boundary is None:
-            boundary = "periodic"
-        if boundary not in _XGCM_BOUNDARY_KWARG_TO_XARRAY_PAD_KWARG:
+        if padding is None:
+            padding = "periodic"
+        if padding not in _XGCM_BOUNDARY_KWARG_TO_XARRAY_PAD_KWARG:
             raise ValueError(
-                f"boundary must be one of {_XGCM_BOUNDARY_KWARG_TO_XARRAY_PAD_KWARG.keys()}, but got {boundary}"
+                f"padding must be one of {_XGCM_BOUNDARY_KWARG_TO_XARRAY_PAD_KWARG.keys()}, but got {padding}"
             )
-        self._boundary = boundary
+        self._padding = padding
 
         if fill_value is None:
             fill_value = 0.0
@@ -130,7 +137,7 @@ class Axis:
 
         # TODO backwards compatible attributes, to be removed --------------------
 
-        if self._boundary == "periodic":
+        if self._padding == "periodic":
             self._periodic = True
         else:
             self._periodic = False
@@ -158,14 +165,21 @@ class Axis:
         return self._default_shifts
 
     @property
+    def padding(self) -> str:
+        return self._padding
+
+    # TODO - remove deprecation handling
+    @property
     def boundary(self) -> str:
-        return self._boundary
+        raise AttributeError(
+            "Attribute 'boundary' has been renamed to 'padding'. "
+            "Please use 'padding' instead."
+        )
 
     def __repr__(self):
         is_periodic = "periodic" if self._periodic else "not periodic"
         summary = [
-            "<xgcm.Axis '%s' (%s, boundary=%r)>"
-            % (self.name, is_periodic, self.boundary)
+            "<xgcm.Axis '%s' (%s, padding=%r)>" % (self.name, is_periodic, self.padding)
         ]
         summary.append("Axis Coordinates:")
         summary += self._coord_desc()

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -73,12 +73,13 @@ class Grid:
         default_shifts: Optional[
             Mapping[str, str]
         ] = None,  # TODO check if one default shift can be applied to many Axes
-        boundary: Optional[Union[str, Mapping[str, str]]] = None,
+        padding: Optional[Union[str, Mapping[str, str]]] = None,
         face_connections: Optional[
             Dict[str, Any]
         ] = None,  # TODO: add more specific typing
         metrics: Optional[Mapping[Tuple[str], List[str]]] = None,  # TODO type hint this
         autoparse_metadata: bool = True,
+        **kwargs,
     ):
         """
         Create a new Grid object from an input dataset.
@@ -103,17 +104,17 @@ class Grid:
             specified (e.g. ``['X', 'Y']``), the axis names in the list will be
             periodic and any other axes founds will be assumed non-periodic.
         fill_value : {float, dict}, optional
-            The value to use in boundary conditions with `boundary='fill'`.
+            The value to use in padding conditions with `padding='fill'`.
             Optionally a dict mapping axis name to seperate values for each axis
             can be passed.
         default_shifts : dict
             A dictionary of dictionaries specifying default grid position
             shifts (e.g. ``{'X': {'center': 'left', 'left': 'center'}}``)
-        boundary : {None, 'fill', 'extend', 'periodic', dict}, optional
-            A flag indicating how to handle boundaries:
+        padding : {None, 'fill', 'extend', 'periodic', dict}, optional
+            A flag indicating how to handle padding:
 
-            * None:  Do not apply any boundary conditions. Raise an error if
-              boundary conditions are required for the operation.
+            * None:  Do not apply any padding conditions. Raise an error if
+              padding conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
               (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
@@ -136,6 +137,13 @@ class Grid:
         ----------
         .. [1] Comodo Conventions https://web.archive.org/web/20160417032300/http://pycomodo.forge.imag.fr/norm.html
         """
+        # TODO - remove deprecation handling
+        if "boundary" in kwargs:
+            raise ValueError(
+                "Argument 'boundary' has been renamed to 'padding'. "
+                "Please use 'padding' instead."
+            )
+
         if not isinstance(ds, xr.Dataset):
             raise TypeError(
                 f"ds argument to `xgcm.Grid` must be of type xarray.Dataset, but is of type {type(ds)}"
@@ -166,11 +174,11 @@ class Grid:
                     default_shifts = parsed_kwargs["default_shifts"]
                 else:
                     duplicates.append("default_shifts")
-            if "boundary" in parsed_kwargs:
-                if boundary is None:
-                    boundary = parsed_kwargs["boundary"]
+            if "padding" in parsed_kwargs:
+                if padding is None:
+                    padding = parsed_kwargs["padding"]
                 else:
-                    duplicates.append("boundary")
+                    duplicates.append("padding")
             if "face_connections" in parsed_kwargs:
                 if face_connections is None:
                     face_connections = parsed_kwargs["face_connections"]
@@ -189,20 +197,11 @@ class Grid:
                     f"autoparse and amend kwargs before calling Grid constructer."
                 )
 
-        if boundary:
-            warnings.warn(
-                "The `boundary` argument will be renamed "
-                "to `padding` to better reflect the process "
-                "of array padding and avoid confusion with "
-                "physical boundary conditions (e.g. ocean land boundary).",
-                category=DeprecationWarning,
-            )
-
         # Deprecation Warnigns
         if periodic:
             warnings.warn(
                 "The `periodic` argument will be deprecated. "
-                "To preserve previous behavior supply `boundary = 'periodic'.",
+                "To preserve previous behavior supply `padding = 'periodic'.",
                 category=DeprecationWarning,
             )
 
@@ -224,7 +223,7 @@ class Grid:
         # Convert all inputs to axes-kwarg mappings
         # TODO We need a way here to check valid input. Maybe also in _as_axis_kwargs?
         # Parse axis properties
-        boundary_dict = self._map_kwargs_over_axes(boundary, axes=all_axes)
+        padding_dict = self._map_kwargs_over_axes(padding, axes=all_axes)
         # TODO: In the future we want this the only place where we store these.
         # TODO: This info needs to then be accessible to e.g. pad()
 
@@ -237,11 +236,11 @@ class Grid:
             periodic_dict = self._map_kwargs_over_axes(periodic, axes=all_axes)
 
         for ax, p in periodic_dict.items():
-            if boundary_dict[ax] is None:
+            if padding_dict[ax] is None:
                 if p is True:
-                    boundary_dict[ax] = "periodic"
+                    padding_dict[ax] = "periodic"
                 else:
-                    boundary_dict[ax] = "fill"
+                    padding_dict[ax] = "fill"
 
         default_shifts_dict = self._map_kwargs_over_axes(default_shifts, axes=all_axes)
 
@@ -266,7 +265,7 @@ class Grid:
                 axis_name,
                 coords=coords[axis_name],
                 default_shifts=default_shifts_dict.get(axis_name, None),
-                boundary=boundary_dict.get(axis_name, None),
+                padding=padding_dict.get(axis_name, None),
                 fill_value=fill_value_dict.get(axis_name, None),
             )
 
@@ -544,7 +543,7 @@ class Grid:
             )
         return metric_vars
 
-    def interp_like(self, array, like, boundary=None, fill_value=None):
+    def interp_like(self, array, like, padding=None, fill_value=None, **kwargs):
         """Compares positions between two data arrays and interpolates array to the position of like if necessary
 
         Parameters
@@ -553,11 +552,11 @@ class Grid:
             DataArray to interpolate to the position of like
         like : DataArray
             DataArray with desired grid positions for source array
-        boundary : {None, 'fill', 'extend', 'periodic', dict}, optional
-            A flag indicating how to handle boundaries:
+        padding : {None, 'fill', 'extend', 'periodic', dict}, optional
+            A flag indicating how to handle padding:
 
-            * None:  Do not apply any boundary conditions. Raise an error if
-              boundary conditions are required for the operation.
+            * None:  Do not apply any padding conditions. Raise an error if
+              padding conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
               (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
@@ -567,13 +566,19 @@ class Grid:
             Optionally a dict mapping axis name to seperate values for each axis
             can be passed.
         fill_value : float, optional
-            The value to use in the boundary condition when `boundary='fill'`.
+            The value to use in the padding condition when `padding='fill'`.
 
         Returns
         -------
         array : DataArray
             Source data array with updated positions along axes matching with target array
         """
+        # TODO - remove deprecation handling
+        if "boundary" in kwargs:
+            raise ValueError(
+                "Argument 'boundary' has been renamed to 'padding'. "
+                "Please use 'padding' instead."
+            )
 
         interp_axes = []
         for axname, axis in self.axes.items():
@@ -593,7 +598,7 @@ class Grid:
             array,
             interp_axes,
             fill_value=fill_value,
-            boundary=boundary,
+            padding=padding,
         )
         return array
 
@@ -602,7 +607,7 @@ class Grid:
         for name, axis in self.axes.items():
             is_periodic = "periodic" if axis._periodic else "not periodic"
             summary.append(
-                "%s Axis (%s, boundary=%r):" % (name, is_periodic, axis.boundary)
+                "%s Axis (%s, padding=%r):" % (name, is_periodic, axis.padding)
             )
             summary += axis._coord_desc()
         return "\n".join(summary)
@@ -763,8 +768,8 @@ class Grid:
         *args: xr.DataArray,
         axis: Optional[Sequence[Sequence[str]]] = None,
         signature: Union[str, _GridUFuncSignature] = "",
-        boundary_width: Optional[Mapping[str, Tuple[int, int]]] = None,
-        boundary: Optional[Union[str, Mapping[str, str]]] = None,
+        padding_width: Optional[Mapping[str, Tuple[int, int]]] = None,
+        padding: Optional[Union[str, Mapping[str, str]]] = None,
         fill_value: Optional[Union[float, Mapping[str, float]]] = None,
         dask: Literal["forbidden", "parallelized", "allowed"] = "forbidden",
         map_overlap: bool = False,
@@ -794,14 +799,14 @@ class Grid:
             positions for each input and output variable, e.g.,
 
             ``"(X:center)->(X:left)"`` for ``diff_center_to_left(a)``.
-        boundary_width : Dict[str: Tuple[int, int]
+        padding_width : Dict[str: Tuple[int, int]
             The widths of the boundaries at the edge of each array.
             Supplied in a mapping of the form {axis_name: (lower_width, upper_width)}.
-        boundary : {None, 'fill', 'extend', 'periodic', dict}, optional
-            A flag indicating how to handle boundaries:
+        padding : {None, 'fill', 'extend', 'periodic', dict}, optional
+            A flag indicating how to handle padding:
 
-            * None:  Do not apply any boundary conditions. Raise an error if
-              boundary conditions are required for the operation.
+            * None:  Do not apply any padding conditions. Raise an error if
+              padding conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
               (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
@@ -811,7 +816,7 @@ class Grid:
             Optionally a dict mapping axis name to seperate values for each axis
             can be passed.
         fill_value : {float, dict}, optional
-            The value to use in boundary conditions with `boundary='fill'`.
+            The value to use in padding conditions with `padding='fill'`.
             Optionally a dict mapping axis name to separate values for each axis
             can be passed. Default is 0.
         dask : {"forbidden", "allowed", "parallelized"}, default: "forbidden"
@@ -833,14 +838,28 @@ class Grid:
         apply_as_grid_ufunc
         as_grid_ufunc
         """
+        # TODO - remove deprecation handling
+        if "boundary" in kwargs:
+            raise ValueError(
+                "Argument 'boundary' has been renamed to 'padding'. "
+                "Please use 'padding' instead."
+            )
+
+        # TODO - remove deprecation handling
+        if "boundary_width" in kwargs:
+            raise ValueError(
+                "Argument 'boundary_width' has been renamed to 'padding_width'. "
+                "Please use 'padding_width' instead."
+            )
+
         return apply_as_grid_ufunc(
             func,
             *args,
             axis=axis,
             grid=self,
             signature=signature,
-            boundary_width=boundary_width,
-            boundary=boundary,
+            padding_width=padding_width,
+            padding=padding,
             fill_value=fill_value,
             dask=dask,
             map_overlap=map_overlap,
@@ -863,7 +882,7 @@ class Grid:
             The direction in which to shift the array (can be ['center','left','right','inner','outer']).
             If not specified, default will be used.
             Optionally a dict with seperate values for each axis can be passed (see example)
-        boundary : None or str or dict, optional
+        padding : None or str or dict, optional
             A flag indicating how to handle boundaries:
 
             * None:  Do not apply any boundary conditions. Raise an error if
@@ -875,7 +894,7 @@ class Grid:
 
             Optionally a dict with separate values for each axis can be passed (see example)
         fill_value : {float, dict}, optional
-            The value to use in the boundary condition with `boundary='fill'`.
+            The value to use in the boundary condition with `padding='fill'`.
             Optionally a dict with seperate values for each axis can be passed (see example)
         vector_partner : dict, optional
             A single key (string), value (DataArray).
@@ -915,7 +934,7 @@ class Grid:
             The direction in which to shift the array (can be ['center','left','right','inner','outer']).
             If not specified, default will be used.
             Optionally a dict with seperate values for each axis can be passed (see example)
-        boundary : None or str or dict, optional
+        padding : None or str or dict, optional
             A flag indicating how to handle boundaries:
 
             * None:  Do not apply any boundary conditions. Raise an error if
@@ -927,7 +946,7 @@ class Grid:
 
             Optionally a dict with separate values for each axis can be passed (see example)
         fill_value : {float, dict}, optional
-            The value to use in the boundary condition with `boundary='fill'`.
+            The value to use in the boundary condition with `padding='fill'`.
             Optionally a dict with seperate values for each axis can be passed (see example)
         vector_partner : dict, optional
             A single key (string), value (DataArray).
@@ -967,7 +986,7 @@ class Grid:
             The direction in which to shift the array (can be ['center','left','right','inner','outer']).
             If not specified, default will be used.
             Optionally a dict with seperate values for each axis can be passed (see example)
-        boundary : None or str or dict, optional
+        padding : None or str or dict, optional
             A flag indicating how to handle boundaries:
 
             * None:  Do not apply any boundary conditions. Raise an error if
@@ -979,7 +998,7 @@ class Grid:
 
             Optionally a dict with separate values for each axis can be passed (see example)
         fill_value : {float, dict}, optional
-            The value to use in the boundary condition with `boundary='fill'`.
+            The value to use in the boundary condition with `padding='fill'`.
             Optionally a dict with seperate values for each axis can be passed (see example)
         vector_partner : dict, optional
             A single key (string), value (DataArray).
@@ -1020,7 +1039,7 @@ class Grid:
             The direction in which to shift the array (can be ['center','left','right','inner','outer']).
             If not specified, default will be used.
             Optionally a dict with seperate values for each axis can be passed (see example)
-        boundary : None or str or dict, optional
+        padding : None or str or dict, optional
             A flag indicating how to handle boundaries:
 
             * None:  Do not apply any boundary conditions. Raise an error if
@@ -1032,7 +1051,7 @@ class Grid:
 
             Optionally a dict with separate values for each axis can be passed (see example)
         fill_value : {float, dict}, optional
-            The value to use in the boundary condition with `boundary='fill'`.
+            The value to use in the boundary condition with `padding='fill'`.
             Optionally a dict with seperate values for each axis can be passed (see example)
         vector_partner : dict, optional
             A single key (string), value (DataArray).
@@ -1064,10 +1083,11 @@ class Grid:
         da: xr.DataArray,
         axis: Union[str, Iterable[str]],
         to=None,
-        boundary=None,
+        padding=None,
         fill_value=None,
         metric_weighted=None,
         keep_coords: bool = False,
+        **kwargs,
     ) -> xr.DataArray:
         """
         Cumulatively sum a DataArray, transforming to the intermediate axis
@@ -1085,7 +1105,7 @@ class Grid:
             The direction in which to shift the array (can be ['center','left','right','inner','outer']).
             If not specified, default will be used.
             Optionally a dict with seperate values for each axis can be passed (see example)
-        boundary : None or str or dict, optional
+        padding : None or str or dict, optional
             A flag indicating how to handle boundaries:
 
             * None:  Do not apply any boundary conditions. Raise an error if
@@ -1097,7 +1117,7 @@ class Grid:
 
             Optionally a dict with separate values for each axis can be passed (see example)
         fill_value : {float, dict}, optional
-            The value to use in the boundary condition with `boundary='fill'`.
+            The value to use in the boundary condition with `padding='fill'`.
             Optionally a dict with seperate values for each axis can be passed (see example)
         metric_weighted : str or tuple of str or dict, optional
             Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.
@@ -1119,6 +1139,12 @@ class Grid:
 
         >>> grid.max(da, ["X", "Y"], fill_value={"X": 0, "Y": 100})
         """
+        # TODO - remove deprecation handling
+        if "boundary" in kwargs:
+            raise ValueError(
+                "Argument 'boundary' has been renamed to 'padding'. "
+                "Please use 'padding' instead."
+            )
 
         if isinstance(axis, str):
             axis = [axis]
@@ -1151,21 +1177,21 @@ class Grid:
                 pos == "left" and ax_to == "center"
             ):
                 # do nothing, this is the default for how cumsum works
-                ax_boundary_width = {ax.name: (0, 0)}
+                ax_padding_width = {ax.name: (0, 0)}
             elif (pos == "center" and ax_to == "left") or (
                 pos == "right" and ax_to == "center"
             ):
                 data = data.isel(**{dim: slice(0, -1)})
-                ax_boundary_width = {ax.name: (1, 0)}
+                ax_padding_width = {ax.name: (1, 0)}
             elif (pos == "center" and ax_to == "inner") or (
                 pos == "outer" and ax_to == "center"
             ):
                 data = data.isel(**{dim: slice(0, -1)})
-                ax_boundary_width = {ax.name: (0, 0)}
+                ax_padding_width = {ax.name: (0, 0)}
             elif (pos == "center" and ax_to == "outer") or (
                 pos == "inner" and ax_to == "center"
             ):
-                ax_boundary_width = {ax.name: (1, 0)}
+                ax_padding_width = {ax.name: (1, 0)}
             else:
                 raise ValueError(
                     f"From `{pos}` to `{ax_to}` is not a valid position "
@@ -1175,8 +1201,8 @@ class Grid:
             padded = pad(
                 data=data,
                 grid=self,
-                boundary_width=ax_boundary_width,
-                boundary=boundary,
+                padding_width=ax_padding_width,
+                padding=padding,
                 fill_value=fill_value,
             )
 
@@ -1190,7 +1216,7 @@ class Grid:
             reattached = _reattach_coords(
                 [coordless],
                 grid=self,
-                boundary_width=ax_boundary_width,
+                padding_width=ax_padding_width,
                 keep_coords=keep_coords,
             )[0]
 
@@ -1293,18 +1319,18 @@ class Grid:
         to : {'center', 'left', 'right', 'inner', 'outer'}
             The direction in which to shift the array. If not specified,
             default will be used.
-        boundary : {None, 'fill', 'extend'}
-            A flag indicating how to handle boundaries:
+        padding : {None, 'fill', 'extend'}
+            A flag indicating how to handle padding:
 
-            * None:  Do not apply any boundary conditions. Raise an error if
-              boundary conditions are required for the operation.
+            * None:  Do not apply any padding conditions. Raise an error if
+              padding conditions are required for the operation.
             * 'fill':  Set values outside the array boundary to fill_value
               (i.e. a Dirichlet boundary condition.)
             * 'extend': Set values outside the array to the nearest array
               value. (i.e. a limited form of Neumann boundary condition.)
 
         fill_value : float, optional
-            The value to use in the boundary condition with `boundary='fill'`.
+            The value to use in the boundary condition with `padding='fill'`.
         vector_partner : dict, optional
             A single key (string), value (DataArray)
         keep_coords : boolean, optional
@@ -1333,7 +1359,7 @@ class Grid:
             The direction in which to shift the array (can be ['center','left','right','inner','outer']).
             If not specified, default will be used.
             Optionally a dict with seperate values for each axis can be passed (see example)
-        boundary : None or str or dict, optional
+        padding : None or str or dict, optional
             A flag indicating how to handle boundaries:
 
             * None:  Do not apply any boundary conditions. Raise an error if
@@ -1345,7 +1371,7 @@ class Grid:
 
             Optionally a dict with separate values for each axis can be passed (see example)
         fill_value : {float, dict}, optional
-            The value to use in the boundary condition with `boundary='fill'`.
+            The value to use in the boundary condition with `padding='fill'`.
             Optionally a dict with seperate values for each axis can be passed (see example)
         vector_partner : dict, optional
             A single key (string), value (DataArray).
@@ -1407,7 +1433,7 @@ class Grid:
             The direction in which to shift the array (can be ['center','left','right','inner','outer']).
             If not specified, default will be used.
             Optionally a dict with separate values for each axis can be passed (see example)
-        boundary : None or str or dict, optional
+        padding : None or str or dict, optional
             A flag indicating how to handle boundaries:
 
             * None:  Do not apply any boundary conditions. Raise an error if
@@ -1419,7 +1445,7 @@ class Grid:
 
             Optionally a dict with separate values for each axis can be passed.
         fill_value : {float, dict}, optional
-            The value to use in the boundary condition with `boundary='fill'`.
+            The value to use in the boundary condition with `padding='fill'`.
             Optionally a dict with separate values for each axis can be passed.
         metric_weighted : str or tuple of str or dict, optional
             Optionally use metrics to multiply/divide with appropriate metrics before/after the operation.

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -334,10 +334,10 @@ class GridUFunc:
         positions for each input and output variable, e.g.,
 
         ``"(X:center)->(X:left)"`` for ``diff_center_to_left(a)`.
-    boundary_width : Dict[str: Tuple[int, int], optional
+    padding_width : Dict[str: Tuple[int, int], optional
         The widths of the boundaries at the edge of each array.
         Supplied in a mapping of the form {axis_name: (lower_width, upper_width)}.
-    boundary : {None, 'fill', 'extend', 'periodic', dict}, optional
+    padding : {None, 'fill', 'extend', 'periodic', dict}, optional
         A flag indicating how to handle boundaries:
 
         * None:  Do not apply any boundary conditions. Raise an error if
@@ -351,7 +351,7 @@ class GridUFunc:
         Optionally a dict mapping axis name to seperate values for each axis
         can be passed.
     fill_value : {float, dict}, optional
-        The value to use in boundary conditions with `boundary='fill'`.
+        The value to use in boundary conditions with `padding='fill'`.
         Optionally a dict mapping axis name to separate values for each axis
         can be passed. Default is 0.
     dask : {"forbidden", "allowed", "parallelized"}, default: "forbidden"
@@ -384,8 +384,8 @@ class GridUFunc:
 
     ufunc: Callable
     signature: _GridUFuncSignature
-    boundary_width: Optional[Mapping[str, Tuple[int, int]]]
-    boundary: Optional[Union[str, Mapping[str, str]]]
+    padding_width: Optional[Mapping[str, Tuple[int, int]]]
+    padding: Optional[Union[str, Mapping[str, str]]]
     fill_value: Optional[Union[float, Mapping[str, float]]]
     dask: Literal["forbidden", "parallelized", "allowed"]
     map_overlap: bool
@@ -394,10 +394,22 @@ class GridUFunc:
     def __init__(self, ufunc: Callable, **kwargs):
         self.ufunc = ufunc  # type: ignore  # see mypy issue 2427
 
+        # TODO - remove deprecation handling
+        if "boundary" in kwargs:
+            raise ValueError(
+                "Argument 'boundary' has been renamed to 'padding'. "
+                "Please use 'padding' instead."
+            )
+        if "boundary_width" in kwargs:
+            raise ValueError(
+                "Argument 'boundary_width' has been renamed to 'padding_width'. "
+                "Please use 'padding_width' instead."
+            )
+
         str_sig = kwargs.pop("signature")
         self.signature = self._get_signature_from_str_or_type_hints(ufunc, str_sig)
-        self.boundary_width = kwargs.pop("boundary_width", None)
-        self.boundary = kwargs.pop("boundary", None)
+        self.padding_width = kwargs.pop("padding_width", None)
+        self.padding = kwargs.pop("padding", None)
         self.fill_value = kwargs.pop("fill_value", None)
         self.dask = kwargs.pop("dask", "forbidden")
         self.map_overlap = kwargs.pop("map_overlap", False)
@@ -445,8 +457,24 @@ class GridUFunc:
 
     def __repr__(self):
         return (
-            f"GridUFunc(ufunc={self.ufunc}, signature='{self.signature}', boundary_width='{self.boundary_width}', "
-            f"          dask='{self.dask})', map_overlap={self.map_overlap}, pad_before_func={self.pad_before_func})"
+            f"GridUFunc(ufunc={self.ufunc}, signature='{self.signature}', padding_width='{self.padding_width}', "
+            f"          padding='{self.padding}', dask='{self.dask})', map_overlap={self.map_overlap}, pad_before_func={self.pad_before_func})"
+        )
+
+    # TODO - remove deprecation handling
+    @property
+    def boundary(self):
+        raise AttributeError(
+            "Attribute 'boundary' has been renamed to 'padding'. "
+            "Please use 'padding' instead."
+        )
+
+    # TODO - remove deprecation handling
+    @property
+    def boundary_width(self):
+        raise AttributeError(
+            "Attribute 'boundary_width' has been renamed to 'padding_width'. "
+            "Please use 'padding_width' instead."
         )
 
     def __call__(
@@ -456,7 +484,14 @@ class GridUFunc:
         axis: Sequence[str],
         **kwargs,
     ):
-        boundary = kwargs.pop("boundary", self.boundary)
+        # TODO - remove deprecation handling
+        if "boundary" in kwargs:
+            raise ValueError(
+                "Argument 'boundary' has been renamed to 'padding'. "
+                "Please use 'padding' instead."
+            )
+
+        padding = kwargs.pop("padding", self.padding)
         dask = kwargs.pop("dask", self.dask)
         map_overlap = kwargs.pop("map_overlap", self.map_overlap)
         pad_before_func = kwargs.pop("pad_before_func", self.pad_before_func)
@@ -466,8 +501,8 @@ class GridUFunc:
             axis=axis,
             grid=grid,
             signature=self.signature,
-            boundary_width=self.boundary_width,
-            boundary=boundary,
+            padding_width=self.padding_width,
+            padding=padding,
             dask=dask,
             map_overlap=map_overlap,
             pad_before_func=pad_before_func,
@@ -477,7 +512,7 @@ class GridUFunc:
 
 def as_grid_ufunc(
     signature: str = "",
-    boundary_width: Optional[Mapping[str, Tuple[int, int]]] = None,
+    padding_width: Optional[Mapping[str, Tuple[int, int]]] = None,
     **kwargs,
 ) -> Callable:
     """
@@ -493,10 +528,10 @@ def as_grid_ufunc(
         positions for each input and output variable, e.g.,
 
         ``"(X:center)->(X:left)"`` for ``diff_center_to_left(a)``.
-    boundary_width : Dict[str: Tuple[int, int], optional
+    padding_width : Dict[str: Tuple[int, int], optional
         The widths of the boundaries at the edge of each array.
         Supplied in a mapping of the form {axis_name: (lower_width, upper_width)}.
-    boundary : {None, 'fill', 'extend', 'periodic', dict}, optional
+    padding : {None, 'fill', 'extend', 'periodic', dict}, optional
         A flag indicating how to handle boundaries:
 
         * None:  Do not apply any boundary conditions. Raise an error if
@@ -510,7 +545,7 @@ def as_grid_ufunc(
         Optionally a dict mapping axis name to seperate values for each axis
         can be passed.
     fill_value : {float, dict}, optional
-        The value to use in boundary conditions with `boundary='fill'`.
+        The value to use in boundary conditions with `padding='fill'`.
         Optionally a dict mapping axis name to separate values for each axis
         can be passed. Default is 0.
     dask : {"forbidden", "allowed", "parallelized"}, default: "forbidden"
@@ -539,8 +574,21 @@ def as_grid_ufunc(
     apply_as_grid_ufunc
     Grid.apply_as_grid_ufunc
     """
+    # TODO - remove deprecation handling
+    if "boundary" in kwargs:
+        raise ValueError(
+            "Argument 'boundary' has been renamed to 'padding'. "
+            "Please use 'padding' instead."
+        )
+    # TODO - remove deprecation handling
+    if "boundary_width" in kwargs:
+        raise ValueError(
+            "Argument 'boundary_width' has been renamed to 'padding_width'. "
+            "Please use 'padding_width' instead."
+        )
+
     _allowedkwargs = {
-        "boundary",
+        "padding",
         "fill_value",
         "dask",
         "map_overlap",
@@ -552,7 +600,7 @@ def as_grid_ufunc(
 
     def _as_grid_ufunc(ufunc):
         return GridUFunc(
-            ufunc, signature=signature, boundary_width=boundary_width, **kwargs
+            ufunc, signature=signature, padding_width=padding_width, **kwargs
         )
 
     return _as_grid_ufunc
@@ -564,8 +612,8 @@ def apply_as_grid_ufunc(
     axis: Optional[Sequence[Sequence[str]]] = None,
     grid: Optional["Grid"] = None,
     signature: Union[str, _GridUFuncSignature] = "",
-    boundary_width: Optional[Mapping[str, Tuple[int, int]]] = None,
-    boundary: Optional[Union[str, Mapping[str, str]]] = None,
+    padding_width: Optional[Mapping[str, Tuple[int, int]]] = None,
+    padding: Optional[Union[str, Mapping[str, str]]] = None,
     fill_value: Optional[Union[float, Mapping[str, float]]] = None,
     keep_coords: bool = True,
     dask: Literal["forbidden", "parallelized", "allowed"] = "forbidden",
@@ -610,11 +658,11 @@ def apply_as_grid_ufunc(
         instance, ``"(Z:center)->(Z:left)"`` is equivalent to ``"(X:center)->(X:left)"`` - both choices of `signature`
         require only that there is exactly one xgcm.Axis name in `axis` which exists in Grid and starts on position
         `center`.
-    boundary_width : Dict[str: Tuple[int, int]
+    padding_width : Dict[str: Tuple[int, int]
         The widths of the boundaries at the edge of each array.
         Supplied in a mapping of the form {dummy_axis_name: (lower_width, upper_width)}.
         The axis names here are again dummy variables, each of which must be present in the signature.
-    boundary : {None, 'fill', 'extend', 'periodic', dict}, optional
+    padding : {None, 'fill', 'extend', 'periodic', dict}, optional
         A flag indicating how to handle boundaries:
 
         * None:  Do not apply any boundary conditions. Raise an error if
@@ -628,7 +676,7 @@ def apply_as_grid_ufunc(
         Optionally a dict mapping axis name to seperate values for each axis
         can be passed.
     fill_value : {float, dict}, optional
-        The value to use in boundary conditions with `boundary='fill'`.
+        The value to use in boundary conditions with `padding='fill'`.
         Optionally a dict mapping axis name to separate values for each axis
         can be passed. Default is 0.
     dask : {"forbidden", "allowed", "parallelized"}, default: "forbidden"
@@ -639,7 +687,7 @@ def apply_as_grid_ufunc(
         Default is False. If True, will need to be accompanied by dask='allowed'.
     pad_before_func : bool, optional
         Whether padding should occur before applying func or after it. Default is True.
-        (For no padding at all pass `boundary_width=None`).
+        (For no padding at all pass `padding_width=None`).
     other_component : Union[None, Dict[str,xr.DataArray], Sequence[Dict[str,xr.DataArray]]], default: None
         Matching vector component for input provided as dictionary. Needed for complex vector padding.
         For multiple arguments, `other_components` needs to provide one element per input.
@@ -661,6 +709,19 @@ def apply_as_grid_ufunc(
     Grid.apply_as_grid_ufunc
     xarray.apply_ufunc
     """
+    # TODO - remove deprecation handling
+    if "boundary" in kwargs:
+        raise ValueError(
+            "Argument 'boundary' has been renamed to 'padding'. "
+            "Please use 'padding' instead."
+        )
+
+    # TODO - remove deprecation handling
+    if "boundary_width" in kwargs:
+        raise ValueError(
+            "Argument 'boundary_width' has been renamed to 'padding_width'. "
+            "Please use 'padding_width' instead."
+        )
 
     if grid is None:
         raise ValueError("Must provide a grid object to describe the Axes")
@@ -741,8 +802,8 @@ def apply_as_grid_ufunc(
     ] * n_output_vars  # assume uniformity of dtypes
 
     # Pad arrays according to boundary condition information
-    boundary_width_real_axes = _substitute_dummy_axis_names(
-        boundary_width, dummy_to_real_axes_mapping
+    padding_width_real_axes = _substitute_dummy_axis_names(
+        padding_width, dummy_to_real_axes_mapping
     )
 
     # Maybe map function over chunked core dims using dask.array.map_overlap
@@ -755,7 +816,7 @@ def apply_as_grid_ufunc(
             args,
             grid,
             in_core_dims,
-            boundary_width_real_axes,
+            padding_width_real_axes,
             out_dtypes,
         )
     else:
@@ -768,8 +829,8 @@ def apply_as_grid_ufunc(
             args,
             grid,
             in_core_dims,
-            boundary_width_real_axes,
-            boundary,
+            padding_width_real_axes,
+            padding,
             fill_value,
             other_component,
         )
@@ -798,8 +859,8 @@ def apply_as_grid_ufunc(
             unpadded_results,
             grid,
             out_core_dims,
-            boundary_width_real_axes,
-            boundary,
+            padding_width_real_axes,
+            padding,
             fill_value,
             other_component,
         )
@@ -808,7 +869,7 @@ def apply_as_grid_ufunc(
 
     # Restore any dimension coordinates associated with new output dims that are present in grid
     # Also throws loud warning if ufunc returns array of incorrect size
-    results_with_coords = _reattach_coords(results, grid, boundary_width, keep_coords)
+    results_with_coords = _reattach_coords(results, grid, padding_width, keep_coords)
 
     # Return single results not wrapped in 1-element tuple, like xr.apply_ufunc does
     if len(results_with_coords) == 1:
@@ -858,27 +919,26 @@ def _apply(
     return results
 
 
-def _substitute_dummy_axis_names(boundary_width, dummy_to_real_axes_mapping):
-    if boundary_width:
-        # convert dummy axes names in boundary_width to match real names of given axes
-        boundary_width_real_axes = {
-            dummy_to_real_axes_mapping[ax]: width
-            for ax, width in boundary_width.items()
+def _substitute_dummy_axis_names(padding_width, dummy_to_real_axes_mapping):
+    if padding_width:
+        # convert dummy axes names in padding_width to match real names of given axes
+        padding_width_real_axes = {
+            dummy_to_real_axes_mapping[ax]: width for ax, width in padding_width.items()
         }
     else:
-        # If the boundary_width kwarg was not specified assume that zero padding is required
-        boundary_width_real_axes = {
+        # If the padding_width kwarg was not specified assume that zero padding is required
+        padding_width_real_axes = {
             real_ax: (0, 0) for real_ax in dummy_to_real_axes_mapping.values()
         }
-    return boundary_width_real_axes
+    return padding_width_real_axes
 
 
 def _pad_then_rechunk(
     args,
     grid,
     in_core_dims,
-    boundary_width_real_axes,
-    boundary,
+    padding_width_real_axes,
+    padding,
     fill_value,
     other_component,
 ):
@@ -886,8 +946,8 @@ def _pad_then_rechunk(
         pad(
             a,
             grid=grid,
-            boundary_width=boundary_width_real_axes,
-            boundary=boundary,
+            padding_width=padding_width_real_axes,
+            padding=padding,
             fill_value=fill_value,
             other_component=oc,
         )
@@ -902,7 +962,7 @@ def _pad_then_rechunk(
         rechunked_padded_args = _rechunk_to_merge_in_boundary_chunks(
             padded_args,
             args,
-            boundary_width_real_axes,
+            padding_width_real_axes,
             grid,
         )
     else:
@@ -928,7 +988,7 @@ def _map_func_over_core_dims(
     original_args,
     grid,
     in_core_dims,
-    boundary_width_real_axes,
+    padding_width_real_axes,
     out_dtypes,
 ):
     """
@@ -945,9 +1005,9 @@ def _map_func_over_core_dims(
         arg.transpose(..., *in_core_dims[i]) for i, arg in enumerate(original_args)
     ]
 
-    boundary_width_per_numpy_axis = {
+    padding_width_per_numpy_axis = {
         grid.axes[ax_name]._get_axis_dim_num(transposed_original_args[0]): width
-        for ax_name, width in boundary_width_real_axes.items()
+        for ax_name, width in padding_width_real_axes.items()
     }
 
     single_dim_chunktype = Tuple[int, ...]
@@ -967,14 +1027,14 @@ def _map_func_over_core_dims(
     # dask.map_overlap needs chunks in terms of axis number, not axis name (i.e. (chunks, ...), not {str: chunks})
     true_chunksizes_per_numpy_axis = _dict_to_numbered_axes(true_chunksizes)
 
-    # (we don't need a separate code path using bare map_blocks if boundary_widths are zero because map_overlap just
+    # (we don't need a separate code path using bare map_blocks if padding_widths are zero because map_overlap just
     # calls map_blocks automatically in that scenario)
     def mapped_func(*a, **kw):
         return dask_map_overlap(
             func,
             *a,
             **kw,
-            depth=boundary_width_per_numpy_axis,
+            depth=padding_width_per_numpy_axis,
             boundary="none",
             trim=False,
             meta=np.array([], dtype=out_dtypes[0]),
@@ -1013,7 +1073,7 @@ def _check_if_length_would_change(signature: _GridUFuncSignature):
 def _rechunk_to_merge_in_boundary_chunks(
     padded_args: Sequence[xr.DataArray],
     original_args: Sequence[xr.DataArray],
-    boundary_width_real_axes: Mapping[str, Tuple[int, int]],
+    padding_width_real_axes: Mapping[str, Tuple[int, int]],
     grid: "Grid",
 ) -> List[xr.DataArray]:
     """Merges in any small floating chunks at the edges that were created by the padding operation"""
@@ -1025,7 +1085,7 @@ def _rechunk_to_merge_in_boundary_chunks(
             grid,
             padded_arg,
             original_arg_chunks,
-            boundary_width_real_axes,
+            padding_width_real_axes,
         )
         rechunked_arg = padded_arg.chunk(merged_boundary_chunks)
         rechunked_padded_args.append(rechunked_arg)
@@ -1037,25 +1097,25 @@ def _get_chunk_pattern_for_merging_boundary(
     grid: "Grid",
     da: xr.DataArray,
     original_chunks: Mapping[str, Tuple[int, ...]],
-    boundary_width_real_axes: Mapping[str, Tuple[int, int]],
+    padding_width_real_axes: Mapping[str, Tuple[int, int]],
 ) -> Mapping[str, Tuple[int, ...]]:
     """Calculates the pattern of chunking needed to merge back in small chunks left on boundaries after padding"""
 
     # Easier to work with width of boundaries in terms of str dimension names rather than int axis numbers
-    boundary_width_dims = {
-        _get_dim(grid, da, ax): width for ax, width in boundary_width_real_axes.items()
+    padding_width_dims = {
+        _get_dim(grid, da, ax): width for ax, width in padding_width_real_axes.items()
     }
 
     new_chunks: Dict[str, Tuple[int, ...]] = {}
-    for dim, width in boundary_width_dims.items():
-        lower_boundary_width, upper_boundary_width = boundary_width_dims[dim]
+    for dim, width in padding_width_dims.items():
+        lower_padding_width, upper_padding_width = padding_width_dims[dim]
 
         new_chunks_along_dim: Tuple[int, ...]
         if len(original_chunks[dim]) == 1:
             # unpadded array had only one chunk, but padding has meant new array is extended
             original_array_length = original_chunks[dim][0]
             new_chunks_along_dim = (
-                lower_boundary_width + original_array_length + upper_boundary_width,
+                lower_padding_width + original_array_length + upper_padding_width,
             )
         else:
             first_chunk_width, *other_chunks_widths, last_chunk_width = original_chunks[
@@ -1063,9 +1123,9 @@ def _get_chunk_pattern_for_merging_boundary(
             ]
             new_chunks_along_dim = tuple(
                 [
-                    first_chunk_width + lower_boundary_width,
+                    first_chunk_width + lower_padding_width,
                     *other_chunks_widths,
-                    last_chunk_width + upper_boundary_width,
+                    last_chunk_width + upper_padding_width,
                 ]
             )
         new_chunks[dim] = new_chunks_along_dim
@@ -1110,7 +1170,7 @@ def _identify_dummy_axes_with_real_axes(
 
 
 def _reattach_coords(
-    results: Sequence[xr.DataArray], grid: "Grid", boundary_width, keep_coords: bool
+    results: Sequence[xr.DataArray], grid: "Grid", padding_width, keep_coords: bool
 ) -> List[xr.DataArray]:
     results_with_coords = []
     for res in results:
@@ -1125,11 +1185,11 @@ def _reattach_coords(
         try:
             res = res.assign_coords(all_matching_coords)
         except ValueError as err:
-            if boundary_width and str(err).startswith("conflicting sizes"):
+            if padding_width and str(err).startswith("conflicting sizes"):
                 # TODO make this error more informative?
                 raise ValueError(
                     f"{str(err)} - does your grid ufunc correctly trim off the same number of elements "
-                    f"which were added by padding using boundary_width={boundary_width}?"
+                    f"which were added by padding using padding_width={padding_width}?"
                 )
             else:
                 raise

--- a/xgcm/gridops.py
+++ b/xgcm/gridops.py
@@ -24,44 +24,44 @@ def diff_forward(a):
     return a[..., 1:] - a[..., :-1]
 
 
-@as_grid_ufunc(signature="(X:center)->(X:left)", boundary_width={"X": (1, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:left)", padding_width={"X": (1, 0)})
 def diff_center_to_left(a):
     return diff_forward(a)
 
 
-@as_grid_ufunc(signature="(X:left)->(X:center)", boundary_width={"X": (0, 1)})
+@as_grid_ufunc(signature="(X:left)->(X:center)", padding_width={"X": (0, 1)})
 def diff_left_to_center(a):
     return diff_forward(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:right)", boundary_width={"X": (0, 1)})
+@as_grid_ufunc(signature="(X:center)->(X:right)", padding_width={"X": (0, 1)})
 def diff_center_to_right(a):
     return diff_forward(a)
 
 
-@as_grid_ufunc(signature="(X:right)->(X:center)", boundary_width={"X": (1, 0)})
+@as_grid_ufunc(signature="(X:right)->(X:center)", padding_width={"X": (1, 0)})
 def diff_right_to_center(a):
     return diff_forward(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:outer)", boundary_width={"X": (1, 1)})
+@as_grid_ufunc(signature="(X:center)->(X:outer)", padding_width={"X": (1, 1)})
 def diff_center_to_outer(a):
     return diff_forward(a)
 
 
-# TODO this actually makes the array end up smaller, but boundary_width={"X": (-1, -1)} is not the correct kwarg value.
-# TODO rename `boundary_width` argument to `pad_width` to better reflect this possibility?
-@as_grid_ufunc(signature="(X:outer)->(X:center)", boundary_width={"X": (0, 0)})
+# TODO this actually makes the array end up smaller, but padding_width={"X": (-1, -1)} is not the correct kwarg value.
+# TODO rename `padding_width` argument to `pad_width` to better reflect this possibility?
+@as_grid_ufunc(signature="(X:outer)->(X:center)", padding_width={"X": (0, 0)})
 def diff_outer_to_center(a):
     return diff_forward(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:inner)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:inner)", padding_width={"X": (0, 0)})
 def diff_center_to_inner(a):
     return diff_forward(a)
 
 
-@as_grid_ufunc(signature="(X:inner)->(X:center)", boundary_width={"X": (1, 1)})
+@as_grid_ufunc(signature="(X:inner)->(X:center)", padding_width={"X": (1, 1)})
 def diff_inner_to_center(a):
     return diff_forward(a)
 
@@ -78,42 +78,42 @@ def interp_forward(a):
     return (a[..., :-1] + a[..., 1:]) / 2.0
 
 
-@as_grid_ufunc(signature="(X:center)->(X:left)", boundary_width={"X": (1, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:left)", padding_width={"X": (1, 0)})
 def interp_center_to_left(a):
     return interp_forward(a)
 
 
-@as_grid_ufunc(signature="(X:left)->(X:center)", boundary_width={"X": (0, 1)})
+@as_grid_ufunc(signature="(X:left)->(X:center)", padding_width={"X": (0, 1)})
 def interp_left_to_center(a):
     return interp_forward(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:right)", boundary_width={"X": (0, 1)})
+@as_grid_ufunc(signature="(X:center)->(X:right)", padding_width={"X": (0, 1)})
 def interp_center_to_right(a):
     return interp_forward(a)
 
 
-@as_grid_ufunc(signature="(X:right)->(X:center)", boundary_width={"X": (1, 0)})
+@as_grid_ufunc(signature="(X:right)->(X:center)", padding_width={"X": (1, 0)})
 def interp_right_to_center(a):
     return interp_forward(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:outer)", boundary_width={"X": (1, 1)})
+@as_grid_ufunc(signature="(X:center)->(X:outer)", padding_width={"X": (1, 1)})
 def interp_center_to_outer(a):
     return interp_forward(a)
 
 
-@as_grid_ufunc(signature="(X:outer)->(X:center)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:outer)->(X:center)", padding_width={"X": (0, 0)})
 def interp_outer_to_center(a):
     return interp_forward(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:inner)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:inner)", padding_width={"X": (0, 0)})
 def interp_center_to_inner(a):
     return interp_forward(a)
 
 
-@as_grid_ufunc(signature="(X:inner)->(X:center)", boundary_width={"X": (1, 1)})
+@as_grid_ufunc(signature="(X:inner)->(X:center)", padding_width={"X": (1, 1)})
 def interp_inner_to_center(a):
     return interp_forward(a)
 
@@ -127,42 +127,42 @@ def pairwise_forward_min(a):
     return np.min(stacked_pairs, axis=-1)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:left)", boundary_width={"X": (1, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:left)", padding_width={"X": (1, 0)})
 def min_center_to_left(a):
     return pairwise_forward_min(a)
 
 
-@as_grid_ufunc(signature="(X:left)->(X:center)", boundary_width={"X": (0, 1)})
+@as_grid_ufunc(signature="(X:left)->(X:center)", padding_width={"X": (0, 1)})
 def min_left_to_center(a):
     return pairwise_forward_min(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:right)", boundary_width={"X": (0, 1)})
+@as_grid_ufunc(signature="(X:center)->(X:right)", padding_width={"X": (0, 1)})
 def min_center_to_right(a):
     return pairwise_forward_min(a)
 
 
-@as_grid_ufunc(signature="(X:right)->(X:center)", boundary_width={"X": (1, 0)})
+@as_grid_ufunc(signature="(X:right)->(X:center)", padding_width={"X": (1, 0)})
 def min_right_to_center(a):
     return pairwise_forward_min(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:outer)", boundary_width={"X": (1, 1)})
+@as_grid_ufunc(signature="(X:center)->(X:outer)", padding_width={"X": (1, 1)})
 def min_center_to_outer(a):
     return pairwise_forward_min(a)
 
 
-@as_grid_ufunc(signature="(X:outer)->(X:center)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:outer)->(X:center)", padding_width={"X": (0, 0)})
 def min_outer_to_center(a):
     return pairwise_forward_min(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:inner)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:inner)", padding_width={"X": (0, 0)})
 def min_center_to_inner(a):
     return pairwise_forward_min(a)
 
 
-@as_grid_ufunc(signature="(X:inner)->(X:center)", boundary_width={"X": (1, 1)})
+@as_grid_ufunc(signature="(X:inner)->(X:center)", padding_width={"X": (1, 1)})
 def min_inner_to_center(a):
     return pairwise_forward_min(a)
 
@@ -176,42 +176,42 @@ def pairwise_forward_max(a):
     return np.max(stacked_pairs, axis=-1)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:left)", boundary_width={"X": (1, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:left)", padding_width={"X": (1, 0)})
 def max_center_to_left(a):
     return pairwise_forward_max(a)
 
 
-@as_grid_ufunc(signature="(X:left)->(X:center)", boundary_width={"X": (0, 1)})
+@as_grid_ufunc(signature="(X:left)->(X:center)", padding_width={"X": (0, 1)})
 def max_left_to_center(a):
     return pairwise_forward_max(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:right)", boundary_width={"X": (0, 1)})
+@as_grid_ufunc(signature="(X:center)->(X:right)", padding_width={"X": (0, 1)})
 def max_center_to_right(a):
     return pairwise_forward_max(a)
 
 
-@as_grid_ufunc(signature="(X:right)->(X:center)", boundary_width={"X": (1, 0)})
+@as_grid_ufunc(signature="(X:right)->(X:center)", padding_width={"X": (1, 0)})
 def max_right_to_center(a):
     return pairwise_forward_max(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:outer)", boundary_width={"X": (1, 1)})
+@as_grid_ufunc(signature="(X:center)->(X:outer)", padding_width={"X": (1, 1)})
 def max_center_to_outer(a):
     return pairwise_forward_max(a)
 
 
-@as_grid_ufunc(signature="(X:outer)->(X:center)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:outer)->(X:center)", padding_width={"X": (0, 0)})
 def max_outer_to_center(a):
     return pairwise_forward_max(a)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:inner)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:inner)", padding_width={"X": (0, 0)})
 def max_center_to_inner(a):
     return pairwise_forward_max(a)
 
 
-@as_grid_ufunc(signature="(X:inner)->(X:center)", boundary_width={"X": (1, 1)})
+@as_grid_ufunc(signature="(X:inner)->(X:center)", padding_width={"X": (1, 1)})
 def max_inner_to_center(a):
     return pairwise_forward_max(a)
 
@@ -221,7 +221,7 @@ def max_inner_to_center(a):
 
 @as_grid_ufunc(
     signature="(X:center)->(X:left)",
-    boundary_width={"X": (1, 0)},
+    padding_width={"X": (1, 0)},
     fill_value=0,
     pad_before_func=False,
 )
@@ -229,19 +229,19 @@ def cumsum_center_to_left(a):
     return np.cumsum(a, axis=-1)[..., :-1]
 
 
-@as_grid_ufunc(signature="(X:left)->(X:center)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:left)->(X:center)", padding_width={"X": (0, 0)})
 def cumsum_left_to_center(a):
     return np.cumsum(a, axis=-1)
 
 
-@as_grid_ufunc(signature="(X:center)->(X:right)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:right)", padding_width={"X": (0, 0)})
 def cumsum_center_to_right(a):
     return np.cumsum(a, axis=-1)
 
 
 @as_grid_ufunc(
     signature="(X:right)->(X:center)",
-    boundary_width={"X": (1, 0)},
+    padding_width={"X": (1, 0)},
     fill_value=0,
     pad_before_func=False,
 )
@@ -251,7 +251,7 @@ def cumsum_right_to_center(a):
 
 @as_grid_ufunc(
     signature="(X:center)->(X:outer)",
-    boundary_width={"X": (1, 0)},
+    padding_width={"X": (1, 0)},
     fill_value=0,
     pad_before_func=False,
 )
@@ -259,19 +259,19 @@ def cumsum_center_to_outer(a):
     return np.cumsum(a, axis=-1)
 
 
-@as_grid_ufunc(signature="(X:outer)->(X:center)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:outer)->(X:center)", padding_width={"X": (0, 0)})
 def cumsum_outer_to_center(a):
     return np.cumsum(a, axis=-1)[..., :-1]
 
 
-@as_grid_ufunc(signature="(X:center)->(X:inner)", boundary_width={"X": (0, 0)})
+@as_grid_ufunc(signature="(X:center)->(X:inner)", padding_width={"X": (0, 0)})
 def cumsum_center_to_inner(a):
     return np.cumsum(a, axis=-1)[..., :-1]
 
 
 @as_grid_ufunc(
     signature="(X:inner)->(X:center)",
-    boundary_width={"X": (1, 0)},
+    padding_width={"X": (1, 0)},
     fill_value=0,
     pad_before_func=False,
 )

--- a/xgcm/padding.py
+++ b/xgcm/padding.py
@@ -347,29 +347,30 @@ def _pad_basic(
 def pad(
     data: Union[xr.DataArray, Dict[str, xr.DataArray]],
     grid: Grid,
-    boundary_width: Optional[Dict[str, Tuple[int, int]]],
-    boundary: Optional[Union[str, Mapping[str, str]]] = None,
+    padding_width: Optional[Dict[str, Tuple[int, int]]],
+    padding: Optional[Union[str, Mapping[str, str]]] = None,
     fill_value: Optional[Union[float, Mapping[str, float]]] = None,
     other_component: Optional[Dict[str, xr.DataArray]] = None,
+    **kwargs,
 ):
     """
-    Pads the boundary of given arrays along given Axes, according to information in Axes.boundary.
+    Pads the boundary of given arrays along given Axes, according to information in Axes.padding.
     Parameters
     ----------
     data :
-        Array to pad according to boundary and boundary_width.
+        Array to pad according to padding and padding_width.
         If a dictionary is passed the input is assumed to be a vector component
         (with the directionof that component identified by the dict key, matching one of the grid axes)
     grid : xgcm.Grid
-        Grid object specifiying the topology and default boundary conditions to use for padding.
-    boundary_width :
+        Grid object specifiying the topology and default padding conditions to use for padding.
+    padding_width :
         The widths of the boundaries at the edge of each array.
         Supplied in a mapping of the form {axis_name: (lower_width, upper_width)}.
-    boundary : {None, 'fill', 'extend', 'periodic', dict}, optional
-        A flag indicating how to handle boundaries:
+    padding : {None, 'fill', 'extend', 'periodic', dict}, optional
+        A flag indicating how to handle padding:
 
-        * None:  Do not apply any boundary conditions. Raise an error if
-            boundary conditions are required for the operation.
+        * None:  Do not apply any padding conditions. Raise an error if
+            padding conditions are required for the operation.
         * 'fill':  Set values outside the array boundary to fill_value
             (i.e. a Dirichlet boundary condition.)
         * 'extend': Set values outside the array to the nearest array
@@ -379,7 +380,7 @@ def pad(
         Optionally a dict mapping axis name to seperate values for each axis
         can be passed.
     fill_value :
-        The value to use in boundary conditions with `boundary='fill'`.
+        The value to use in padding conditions with `padding='fill'`.
         Optionally a dict mapping axis name to separate values for each axis
         can be passed. Default is 0.
     other_component :
@@ -388,12 +389,22 @@ def pad(
         dict key, matching one of the grid axes)
     """
 
-    # TODO rename this globally
-    padding = boundary
-    padding_width = boundary_width
+    # TODO - remove deprecation handling
+    if "boundary" in kwargs:
+        raise ValueError(
+            "Argument 'boundary' has been renamed to 'padding'. "
+            "Please use 'padding' instead."
+        )
+
+    # TODO - remove deprecation handling
+    if "boundary_width" in kwargs:
+        raise ValueError(
+            "Argument 'boundary_width' has been renamed to 'padding_width'. "
+            "Please use 'padding_width' instead."
+        )
 
     # Always promote the padding/fill_value to a dict of form {ax: kwarg}.
-    padding = grid._complete_user_kwargs_using_axis_defaults(padding, "boundary")
+    padding = grid._complete_user_kwargs_using_axis_defaults(padding, "padding")
     fill_value = grid._complete_user_kwargs_using_axis_defaults(
         fill_value, "fill_value"
     )

--- a/xgcm/test/test_axis.py
+++ b/xgcm/test/test_axis.py
@@ -17,7 +17,7 @@ class TestInit:
 
         # test default values of attributes
         assert axis.default_shifts == {"left": "center", "center": "left"}
-        assert axis.boundary == "periodic"
+        assert axis.padding == "periodic"
 
     def test_override_defaults(self, periodic_1d):
         # test initialisation
@@ -28,7 +28,7 @@ class TestInit:
             coords={"center": "XC", "left": "XG"},
             # TODO does this make sense as default shifts?
             default_shifts={"left": "inner", "center": "outer"},
-            boundary="fill",
+            padding="fill",
         )
 
         # test attributes
@@ -38,7 +38,7 @@ class TestInit:
         # test default values of attributes
         # TODO (these deafult shift values make no physical sense)
         assert axis.default_shifts == {"left": "inner", "center": "outer"}
-        assert axis.boundary == "fill"
+        assert axis.padding == "fill"
 
     def test_inconsistent_dims(self, periodic_1d):
         """Test when xgcm coord names are not present in dataset dims"""
@@ -62,12 +62,12 @@ class TestInit:
                 default_shifts={"left": "left", "center": "center"},
             )
 
-        with pytest.raises(ValueError, match="boundary must be one of"):
+        with pytest.raises(ValueError, match="padding must be one of"):
             Axis(
                 name="foo",
                 ds=ds,
                 coords={"center": "XC", "left": "XG"},
-                boundary="blargh",
+                padding="blargh",
             )
 
     def test_repr(self, periodic_1d):

--- a/xgcm/test/test_deprecations.py
+++ b/xgcm/test/test_deprecations.py
@@ -23,10 +23,10 @@ def test_periodic_true_deprecation():
         )
 
 
-def test_boundary_deprecation():
+def test_padding_deprecation():
     ds = datasets["2d_left"]
     with pytest.raises(
-        DeprecationWarning, match="The `boundary` argument is deprecated"
+        ValueError, match="Argument 'boundary' has been renamed to 'padding'"
     ):
         xgcm.Grid(
             ds,

--- a/xgcm/test/test_deprecations.py
+++ b/xgcm/test/test_deprecations.py
@@ -1,0 +1,39 @@
+import pytest
+
+import xgcm
+from xgcm.test.datasets import datasets
+
+pytestmark = pytest.mark.filterwarnings("error")
+
+
+def test_periodic_true_deprecation():
+    ds = datasets["2d_left"]
+    with pytest.raises(
+        DeprecationWarning,
+        match="The `periodic` argument will be deprecated. To preserve previous behavior supply `padding = 'periodic'.",
+    ):
+        xgcm.Grid(
+            ds,
+            coords={
+                "X": {"left": "XG", "center": "XC"},
+                "Y": {"left": "YG", "center": "YC"},
+            },
+            autoparse_metadata=False,
+            periodic=True,
+        )
+
+
+def test_boundary_deprecation():
+    ds = datasets["2d_left"]
+    with pytest.raises(
+        DeprecationWarning, match="The `boundary` argument is deprecated"
+    ):
+        xgcm.Grid(
+            ds,
+            coords={
+                "X": {"left": "XG", "center": "XC"},
+                "Y": {"left": "YG", "center": "YC"},
+            },
+            autoparse_metadata=False,
+            boundary="periodic",
+        )

--- a/xgcm/test/test_faceconnections.py
+++ b/xgcm/test/test_faceconnections.py
@@ -164,8 +164,8 @@ def test_create_connected_grid_error_wrong_facedim(ds, ds_face_connections_x_to_
 def test_diff_interp_connected_grid_x_to_x(ds, ds_face_connections_x_to_x):
     # simplest scenario with one face connection
     grid = Grid(ds, face_connections=ds_face_connections_x_to_x, periodic=False)
-    diff_x = grid.diff(ds.data_c, "X", boundary="fill")
-    interp_x = grid.interp(ds.data_c, "X", boundary="fill")
+    diff_x = grid.diff(ds.data_c, "X", padding="fill")
+    interp_x = grid.interp(ds.data_c, "X", padding="fill")
 
     # make sure the face connection got applied correctly
     np.testing.assert_allclose(
@@ -175,7 +175,7 @@ def test_diff_interp_connected_grid_x_to_x(ds, ds_face_connections_x_to_x):
         interp_x[1, :, 0], 0.5 * (ds.data_c[1, :, 0] + ds.data_c[0, :, -1])
     )
 
-    # make sure the left boundary got applied correctly
+    # make sure the left padding got applied correctly
     np.testing.assert_allclose(diff_x[0, :, 0], ds.data_c[0, :, 0] - 0.0)
     np.testing.assert_allclose(interp_x[0, :, 0], 0.5 * (ds.data_c[0, :, 0] + 0.0))
 
@@ -184,8 +184,8 @@ def test_diff_interp_connected_grid_x_to_y(ds, ds_face_connections_x_to_y):
     # one face connection, rotated
     grid = Grid(ds, face_connections=ds_face_connections_x_to_y)
 
-    diff_y = grid.diff(ds.data_c, "Y", boundary="fill")
-    interp_y = grid.interp(ds.data_c, "Y", boundary="fill")
+    diff_y = grid.diff(ds.data_c, "Y", padding="fill")
+    interp_y = grid.interp(ds.data_c, "Y", padding="fill")
 
     # make sure the face connection got applied correctly
     # non-same axis connections require rotation
@@ -202,18 +202,18 @@ def test_diff_interp_connected_grid_x_to_y(ds, ds_face_connections_x_to_y):
     # TODO: checking all the other boundaries
 
 
-@pytest.mark.parametrize("boundary", ["periodic", "fill"])
-def test_vector_connected_grid_x_to_y(ds, ds_face_connections_x_to_y, boundary):
+@pytest.mark.parametrize("padding", ["periodic", "fill"])
+def test_vector_connected_grid_x_to_y(ds, ds_face_connections_x_to_y, padding):
     # one face connection, rotated
     grid = Grid(
         ds,
         face_connections=ds_face_connections_x_to_y,
-        boundary=boundary,
+        padding=padding,
         fill_value=1,
         periodic=False,
     )
     # TODO: Remove the periodic once that is deprecated.
-    # ! Set boundary on grid, so it is applied to all axes.
+    # ! Set padding on grid, so it is applied to all axes.
     # TODO: modify the non velocity tests too (after release)
 
     # modify the values of the dataset, so we know what to expect from the output
@@ -259,7 +259,7 @@ def test_vector_diff_interp_connected_grid_x_to_y(
     vector_center = grid.interp_2d_vector(
         {"X": ds.u, "Y": ds.v},
         to="center",
-        boundary="fill",
+        padding="fill",
         fill_value=100,
     )
     u_c_interp = vector_center["X"]
@@ -267,7 +267,7 @@ def test_vector_diff_interp_connected_grid_x_to_y(
     vector_diff = grid.diff_2d_vector(
         {"X": ds.u, "Y": ds.v},
         to="center",
-        boundary="fill",
+        padding="fill",
         fill_value=100,
     )
     u_c_diff = vector_diff["X"]
@@ -290,9 +290,9 @@ def test_vector_diff_interp_connected_grid_x_to_y(
 
     # TODO: figure out tangent vectors
     with pytest.raises(NotImplementedError):
-        _ = grid.interp_2d_vector({"X": ds.v, "Y": ds.u}, to="left", boundary="fill")
+        _ = grid.interp_2d_vector({"X": ds.v, "Y": ds.u}, to="left", padding="fill")
     with pytest.raises(NotImplementedError):
-        _ = grid.interp_2d_vector({"X": ds.v, "Y": ds.u}, boundary="fill")
+        _ = grid.interp_2d_vector({"X": ds.v, "Y": ds.u}, padding="fill")
 
 
 def test_create_cubed_sphere_grid(cs, cubed_sphere_connections):

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -111,7 +111,7 @@ def test_raise_on_operation_not_valid_for_same_position():
 
 
 @pytest.mark.parametrize(
-    "boundary",
+    "padding",
     [
         "fill",
         "extend",
@@ -119,24 +119,24 @@ def test_raise_on_operation_not_valid_for_same_position():
     ],
 )
 @pytest.mark.parametrize("fill_value", [0, 1.0])
-def test_grid_create(all_datasets, boundary, fill_value):
+def test_grid_create(all_datasets, padding, fill_value):
     ds, periodic, expected = all_datasets
     grid = Grid(ds, periodic=periodic)
 
     assert grid is not None
 
     for ax in grid.axes.values():
-        assert ax.boundary == "periodic" if periodic else "fill"
+        assert ax.padding == "periodic" if periodic else "fill"
         assert ax.fill_value == 0.0
 
-    grid = Grid(ds, periodic=periodic, boundary=boundary, fill_value=fill_value)
+    grid = Grid(ds, periodic=periodic, padding=padding, fill_value=fill_value)
 
     for name, ax in grid.axes.items():
-        if isinstance(boundary, dict):
-            expected = boundary.get(name)
+        if isinstance(padding, dict):
+            expected = padding.get(name)
         else:
-            expected = boundary
-        assert ax.boundary == expected
+            expected = padding
+        assert ax.padding == expected
 
         if isinstance(fill_value, dict):
             expected = fill_value.get(name)
@@ -183,38 +183,38 @@ def test_grid_repr(all_datasets):
     assert r[0] == "<xgcm.Grid>"
 
 
-@pytest.mark.parametrize("boundary", ["extend", "fill"])
-def test_cumsum(nonperiodic_1d, boundary):
+@pytest.mark.parametrize("padding", ["extend", "fill"])
+def test_cumsum(nonperiodic_1d, padding):
     ds, periodic, expected = nonperiodic_1d
-    grid = Grid(ds, boundary="periodic")
+    grid = Grid(ds, padding="periodic")
 
-    cumsum_g = grid.cumsum(ds.data_g, axis="X", to="center", boundary=boundary)
+    cumsum_g = grid.cumsum(ds.data_g, axis="X", to="center", padding=padding)
 
     to = grid.axes["X"].default_shifts["center"]
-    cumsum_c = grid.cumsum(ds.data_c, axis="X", to=to, boundary=boundary)
+    cumsum_c = grid.cumsum(ds.data_c, axis="X", to=to, padding=padding)
 
     cumsum_c_raw = np.cumsum(ds.data_c.data)
     cumsum_g_raw = np.cumsum(ds.data_g.data)
 
     if to == "right":
         np.testing.assert_allclose(cumsum_c.data, cumsum_c_raw)
-        fill_value = 0.0 if boundary == "fill" else cumsum_g_raw[0]
+        fill_value = 0.0 if padding == "fill" else cumsum_g_raw[0]
         np.testing.assert_allclose(
             cumsum_g.data, np.hstack([fill_value, cumsum_g_raw[:-1]])
         )
     elif to == "left":
         np.testing.assert_allclose(cumsum_g.data, cumsum_g_raw)
-        fill_value = 0.0 if boundary == "fill" else cumsum_c_raw[0]
+        fill_value = 0.0 if padding == "fill" else cumsum_c_raw[0]
         np.testing.assert_allclose(
             cumsum_c.data, np.hstack([fill_value, cumsum_c_raw[:-1]])
         )
     elif to == "inner":
         np.testing.assert_allclose(cumsum_c.data, cumsum_c_raw[:-1])
-        fill_value = 0.0 if boundary == "fill" else cumsum_g_raw[0]
+        fill_value = 0.0 if padding == "fill" else cumsum_g_raw[0]
         np.testing.assert_allclose(cumsum_g.data, np.hstack([fill_value, cumsum_g_raw]))
     elif to == "outer":
         np.testing.assert_allclose(cumsum_g.data, cumsum_g_raw[:-1])
-        fill_value = 0.0 if boundary == "fill" else cumsum_c_raw[0]
+        fill_value = 0.0 if padding == "fill" else cumsum_c_raw[0]
         np.testing.assert_allclose(cumsum_c.data, np.hstack([fill_value, cumsum_c_raw]))
 
     # not much point doing this...we don't have the right test datasets
@@ -222,7 +222,7 @@ def test_cumsum(nonperiodic_1d, boundary):
     # other_positions = {'left', 'right', 'inner', 'outer'}.difference({to})
     # for pos in other_positions:
     #     with pytest.raises(KeyError):
-    #         axis.cumsum(ds.data_c, to=pos, boundary=boundary)
+    #         axis.cumsum(ds.data_c, to=pos, padding=padding)
 
 
 @pytest.mark.parametrize(
@@ -230,7 +230,7 @@ def test_cumsum(nonperiodic_1d, boundary):
     ["interp", "max", "min", "diff", "cumsum"],
 )
 @pytest.mark.parametrize(
-    "boundary",
+    "padding",
     [
         "fill",
         "extend",
@@ -238,16 +238,16 @@ def test_cumsum(nonperiodic_1d, boundary):
         {"X": "extend", "Y": "fill"},
     ],
 )
-def test_dask_vs_eager(all_datasets, func, boundary):
+def test_dask_vs_eager(all_datasets, func, padding):
     ds, coords, metrics = datasets_grid_metric("C")
     grid = Grid(ds, coords=coords, autoparse_metadata=False)
     grid_method = getattr(grid, func)
-    eager_result = grid_method(ds.tracer, "X", boundary=boundary)
+    eager_result = grid_method(ds.tracer, "X", padding=padding)
 
     ds = ds.chunk({"xt": 1, "yt": 1, "time": 1, "zt": 1})
     grid = Grid(ds, coords=coords, autoparse_metadata=False)
     grid_method = getattr(grid, func)
-    dask_result = grid_method(ds.tracer, "X", boundary=boundary).compute()
+    dask_result = grid_method(ds.tracer, "X", padding=padding).compute()
 
     xr.testing.assert_allclose(dask_result, eager_result)
 
@@ -260,7 +260,7 @@ def test_grid_dict_input_boundary_fill(nonperiodic_1d):
         ds,
         coords=grid_kwargs["coords"],
         periodic=False,
-        boundary="fill",
+        padding="fill",
         fill_value=5,
         autoparse_metadata=False,
     )
@@ -268,24 +268,24 @@ def test_grid_dict_input_boundary_fill(nonperiodic_1d):
         ds,
         coords=grid_kwargs["coords"],
         periodic=False,
-        boundary={"X": "fill"},
+        padding={"X": "fill"},
         fill_value={"X": 5},
         autoparse_metadata=False,
     )
     assert grid_direct.axes["X"].fill_value == grid_dict.axes["X"].fill_value
-    assert grid_direct.axes["X"].boundary == grid_dict.axes["X"].boundary
+    assert grid_direct.axes["X"].padding == grid_dict.axes["X"].padding
 
 
-def test_invalid_boundary_error():
+def test_invalid_padding_error():
     ds = datasets["1d_left"]
     with pytest.raises(ValueError):
-        Grid(ds, boundary="bad", autoparse_metadata=False)
+        Grid(ds, padding="bad", autoparse_metadata=False)
     with pytest.raises(ValueError):
-        Grid(ds, boundary={"X": "bad"}, autoparse_metadata=False)
+        Grid(ds, padding={"X": "bad"}, autoparse_metadata=False)
     with pytest.raises(ValueError):
-        Grid(ds, boundary={"X": 0}, autoparse_metadata=False)
+        Grid(ds, padding={"X": 0}, autoparse_metadata=False)
     with pytest.raises(ValueError):
-        Grid(ds, boundary=0, autoparse_metadata=False)
+        Grid(ds, padding=0, autoparse_metadata=False)
 
 
 def test_invalid_fill_value_error():
@@ -359,18 +359,18 @@ def test_keep_coords_deprecation():
             grid.diff(ds.tracer, axis_name, keep_coords=False)
 
 
-def test_boundary_kwarg_same_as_grid_constructor_kwarg():
+def test_padding_kwarg_same_as_grid_constructor_kwarg():
     ds = datasets["2d_left"]
     ds, grid_kwargs = parse_comodo(ds)
     grid1 = Grid(ds, coords=grid_kwargs["coords"], autoparse_metadata=False)
     grid2 = Grid(
         ds,
         coords=grid_kwargs["coords"],
-        boundary={"X": "fill", "Y": "fill"},
+        padding={"X": "fill", "Y": "fill"},
         autoparse_metadata=False,
     )
 
-    actual1 = grid1.interp(ds.data_g, ("X", "Y"), boundary={"X": "fill", "Y": "fill"})
+    actual1 = grid1.interp(ds.data_g, ("X", "Y"), padding={"X": "fill", "Y": "fill"})
     actual2 = grid2.interp(ds.data_g, ("X", "Y"))
 
     xr.testing.assert_identical(actual1, actual2)
@@ -388,7 +388,7 @@ def test_boundary_kwarg_same_as_grid_constructor_kwarg():
 )
 @pytest.mark.parametrize("periodic", [True, False])
 @pytest.mark.parametrize(
-    "boundary, boundary_expected",
+    "padding, padding_expected",
     [
         ({"X": "fill", "Y": "fill"}, {"X": "fill", "Y": "fill"}),
         ({"X": "extend", "Y": "extend"}, {"X": "extend", "Y": "extend"}),
@@ -399,13 +399,13 @@ def test_boundary_kwarg_same_as_grid_constructor_kwarg():
             "fill",
             {"X": "fill", "Y": "extend"},
             marks=pytest.mark.xfail,
-            id="boundary not equal to boundary_expected",
+            id="padding not equal to padding_expected",
         ),
     ],
 )
 @pytest.mark.parametrize("fill_value", [None, 0.1])
 def test_interp_like(
-    metric_axes, metric_name, periodic, boundary, boundary_expected, fill_value
+    metric_axes, metric_name, periodic, padding, padding_expected, fill_value
 ):
     ds, coords, _ = datasets_grid_metric("C")
     grid = Grid(ds, coords=coords, periodic=periodic, autoparse_metadata=False)
@@ -413,10 +413,10 @@ def test_interp_like(
     metric_available = grid._metrics.get(frozenset(metric_axes), None)
     metric_available = metric_available[0]
     interp_metric = grid.interp_like(
-        metric_available, ds.u, boundary=boundary, fill_value=fill_value
+        metric_available, ds.u, padding=padding, fill_value=fill_value
     )
     expected_metric = grid.interp(
-        ds[metric_name], metric_axes, boundary=boundary_expected, fill_value=fill_value
+        ds[metric_name], metric_axes, padding=padding_expected, fill_value=fill_value
     )
 
     xr.testing.assert_allclose(interp_metric, expected_metric)
@@ -456,46 +456,44 @@ def test_input_dim_notfound():
     ],
 )
 @pytest.mark.parametrize(
-    "boundary",
+    "padding",
     ["fill", "extend"],
 )
 @pytest.mark.parametrize(
     "fill_value",
     [0, 10, None],
 )
-def test_boundary_global_input(funcname, boundary, fill_value):
-    """Test that globally defined boundary values result in
+def test_padding_global_input(funcname, padding, fill_value):
+    """Test that globally defined padding values result in
     the same output as when the parameters are defined the grid methods
     """
     ds, coords, metrics = datasets_grid_metric("C")
     axis = "X"
-    # Test results by globally specifying fill value/boundary on grid object
+    # Test results by globally specifying fill value/padding on grid object
     grid_global = Grid(
         ds,
         coords=coords,
         metrics=metrics,
         periodic=False,
-        boundary=boundary,
+        padding=padding,
         fill_value=fill_value,
         autoparse_metadata=False,
     )
     func_global = getattr(grid_global, funcname)
     global_result = func_global(ds.tracer, axis)
 
-    # Test results by manually specifying fill value/boundary on grid method
+    # Test results by manually specifying fill value/padding on grid method
     grid_manual = Grid(
         ds,
         coords=coords,
         metrics=metrics,
         periodic=False,
-        boundary=boundary,
+        padding=padding,
         autoparse_metadata=False,
     )
 
     func_manual = getattr(grid_manual, funcname)
-    manual_result = func_manual(
-        ds.tracer, axis, boundary=boundary, fill_value=fill_value
-    )
+    manual_result = func_manual(ds.tracer, axis, padding=padding, fill_value=fill_value)
     xr.testing.assert_allclose(global_result, manual_result)
 
 

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -628,7 +628,7 @@ class TestGridUfuncWithPadding:
             axis=[("depth",)],
             grid=grid,
             signature="(X:center)->(X:center)",
-            boundary_width={"X": (2, 0)},
+            padding_width={"X": (2, 0)},
         )
         assert_equal(result, expected)
 
@@ -657,7 +657,7 @@ class TestGridUfuncWithPadding:
             axis=[("depth",)],
             grid=grid,
             signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
+            padding_width={"X": (1, 0)},
             dask="parallelized",
         ).compute()
         assert_equal(result, expected)
@@ -668,7 +668,7 @@ class TestGridUfuncWithPadding:
             da,
             axis=[("depth",)],
             signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
+            padding_width={"X": (1, 0)},
             dask="parallelized",
         )
         assert_equal(result, expected)
@@ -676,7 +676,7 @@ class TestGridUfuncWithPadding:
         # Test decorator
         @as_grid_ufunc(
             "(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
+            padding_width={"X": (1, 0)},
             dask="parallelized",
         )
         def diff_center_to_left(a):
@@ -725,7 +725,7 @@ class TestGridUfuncWithPadding:
             V,
             axis=2 * [("lon", "lat")],
             signature="(lon:left,lat:center),(lon:center,lat:left)->(lon:left,lat:left)",
-            boundary_width={"lon": (1, 0), "lat": (1, 0)},
+            padding_width={"lon": (1, 0), "lat": (1, 0)},
             dask="parallelized",  # data isn't chunked along lat/lon
         )
         assert_equal(result, expected)
@@ -765,7 +765,7 @@ class TestPadManuallyInsideUfunc:
             axis=[("depth",)],
             grid=grid,
             signature="(X:center)->(X:center)",
-            boundary_width=None,
+            padding_width=None,
         )
         assert_equal(result, expected)
 
@@ -791,8 +791,8 @@ class TestPadAfterUFunc:
             axis=[("depth",)],
             grid=grid,
             signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
-            boundary="fill",
+            padding_width={"X": (1, 0)},
+            padding="fill",
             fill_value=0,
             pad_before_func=False,
         )
@@ -819,8 +819,8 @@ class TestPadAfterUFunc:
             axis=[("depth",)],
             grid=grid,
             signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
-            boundary="fill",
+            padding_width={"X": (1, 0)},
+            padding="fill",
             fill_value=0,
             pad_before_func=False,
             dask="allowed",
@@ -845,8 +845,8 @@ class TestPadAfterUFunc:
             ds, coords={"Z": {"center": "Z", "outer": "Zp1"}}, autoparse_metadata=False
         )
 
-        grid.cumsum(ds.drF, "Z", boundary="periodic")
-        grid.cumsum(ds.drF, "Z", boundary="extend")
+        grid.cumsum(ds.drF, "Z", padding="periodic")
+        grid.cumsum(ds.drF, "Z", padding="extend")
 
 
 class TestDaskNoOverlap:
@@ -878,7 +878,7 @@ class TestDaskOverlap:
             axis=[("depth",)],
             grid=grid,
             signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
+            padding_width={"X": (1, 0)},
             dask="allowed",
             map_overlap=True,
         ).compute()
@@ -890,7 +890,7 @@ class TestDaskOverlap:
             da,
             axis=[("depth",)],
             signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
+            padding_width={"X": (1, 0)},
             dask="allowed",
             map_overlap=True,
         )
@@ -898,7 +898,7 @@ class TestDaskOverlap:
 
         # Test decorator
         @as_grid_ufunc(
-            boundary_width={"X": (1, 0)},
+            padding_width={"X": (1, 0)},
             dask="allowed",
             map_overlap=True,
         )
@@ -921,7 +921,7 @@ class TestDaskOverlap:
         raise NotImplementedError
 
     @pytest.mark.xfail
-    def test_gave_axis_but_no_corresponding_boundary_width(self):
+    def test_gave_axis_but_no_corresponding_padding_width(self):
         # TODO this should default to zero
         raise NotImplementedError
 
@@ -944,7 +944,7 @@ class TestDaskOverlap:
             axis=[("depth",)],
             grid=grid,
             signature="(X:left)->(X:left)",
-            boundary_width=None,
+            padding_width=None,
             dask="allowed",
             map_overlap=True,
         ).compute()
@@ -960,7 +960,7 @@ class TestDaskOverlap:
 
     def test_raise_when_ufunc_changes_chunksize(self):
         @as_grid_ufunc(
-            boundary_width={"X": (1, 0)},
+            padding_width={"X": (1, 0)},
             dask="allowed",
             map_overlap=True,
         )
@@ -988,7 +988,7 @@ class TestDaskOverlap:
 
     def test_multiple_inputs(self):
         @as_grid_ufunc(
-            boundary_width=None,
+            padding_width=None,
             map_overlap=True,
             dask="allowed",
         )
@@ -1049,8 +1049,8 @@ class TestBoundary:
 
         @as_grid_ufunc(
             signature="(X:center)->(X:left)",
-            boundary_width={"X": (1, 0)},
-            boundary="fill",
+            padding_width={"X": (1, 0)},
+            padding="fill",
             fill_value=0,
         )
         def interp_center_to_left(a):
@@ -1068,7 +1068,7 @@ class TestBoundary:
 
         # test that bound kwargs can be overridden at call time
         result = interp_center_to_left(
-            grid, da, axis=[["lat"]], boundary="fill", fill_value=1
+            grid, da, axis=[["lat"]], padding="fill", fill_value=1
         )
         interped_arr_padded_with_one = interp(np.concatenate([[1], arr]))
         expected = grid._ds.lat_g.copy(data=interped_arr_padded_with_one)
@@ -1134,7 +1134,7 @@ class TestMapOverlapGridops:
             .to_dataset(name="drF")
         )
 
-        result = grid.interp(ds.drF, "Z", boundary="extend", to="outer").to_dataset(
+        result = grid.interp(ds.drF, "Z", padding="extend", to="outer").to_dataset(
             name="drF"
         )
         assert_equal(result, expected)
@@ -1227,7 +1227,7 @@ class TestGridUFuncDispatch:
             "diff",
             _GridUFuncSignature.from_string("(X:center)->(X:right)"),
             module=GridOpsMockUp,
-            boundary="fill",
+            padding="fill",
         )
         assert gridufunc is GridOpsMockUp.diff_center_to_right_fill
 
@@ -1236,7 +1236,7 @@ class TestGridUFuncDispatch:
                 "diff",
                 _GridUFuncSignature.from_string("(X:center)->(X:right)"),
                 module=GridOpsMockUp,
-                boundary="nonsense",
+                padding="nonsense",
             )
 
     @pytest.mark.xfail
@@ -1246,6 +1246,6 @@ class TestGridUFuncDispatch:
             "pass",
             _GridUFuncSignature.from_string("()->()"),
             module=GridOpsMockUp,
-            boundary="fill",
+            padding="fill",
         )
         assert gridufunc(a=1) == {"a": 1}

--- a/xgcm/test/test_metrics.py
+++ b/xgcm/test/test_metrics.py
@@ -191,7 +191,7 @@ def test_get_metric_with_conditions_02a(periodic):
         ds,
         coords=coords,
         periodic=periodic,
-        boundary="extend",
+        padding="extend",
         autoparse_metadata=False,
     )
     grid.set_metrics(("X", "Y"), "area_e")

--- a/xgcm/test/test_metrics_ops.py
+++ b/xgcm/test/test_metrics_ops.py
@@ -20,14 +20,14 @@ from xgcm.test.datasets import datasets_grid_metric
 @pytest.mark.parametrize("grid_type", ["B", "C"])
 @pytest.mark.parametrize("variable", ["tracer", "u", "v"])
 @pytest.mark.parametrize("metric_weighted", ["X", ("Y",), ("X", "Y"), ["X", "Y"]])
-@pytest.mark.parametrize("boundary", ["fill", "extend"])
+@pytest.mark.parametrize("padding", ["fill", "extend"])
 class TestParametrized:
     @pytest.mark.parametrize("axis", ["X", "Y"])
     @pytest.mark.parametrize(
         "periodic", ["True", "False", {"X": True, "Y": False}, {"X": False, "Y": True}]
     )
     def test_weighted_metric(
-        self, funcname, grid_type, variable, axis, metric_weighted, periodic, boundary
+        self, funcname, grid_type, variable, axis, metric_weighted, periodic, padding
     ):
         """tests the correct execution of weighted ops along a single axis"""
         # metric_weighted allows the interpolation of e.g. a surface flux to be conservative
@@ -44,17 +44,15 @@ class TestParametrized:
         func = getattr(grid, funcname)
 
         metric = grid.get_metric(ds[variable], metric_weighted)
-        expected_raw = func(ds[variable] * metric, axis, boundary=boundary)
+        expected_raw = func(ds[variable] * metric, axis, padding=padding)
         metric_new = grid.get_metric(expected_raw, metric_weighted)
         expected = expected_raw / metric_new
-        new = func(
-            ds[variable], axis, metric_weighted=metric_weighted, boundary=boundary
-        )
+        new = func(ds[variable], axis, metric_weighted=metric_weighted, padding=padding)
         assert new.equals(expected)
 
     @pytest.mark.parametrize("multi_axis", ["X", ["X"], ("Y"), ["X", "Y"], ("Y", "X")])
     def test_weighted_metric_multi_axis(
-        self, funcname, grid_type, variable, multi_axis, metric_weighted, boundary
+        self, funcname, grid_type, variable, multi_axis, metric_weighted, padding
     ):
         """tests if the output for multiple axis is the same as when
         executing the single axis ops in serial"""
@@ -72,14 +70,14 @@ class TestParametrized:
                 expected,
                 ax,
                 metric_weighted=metric_weighted_axis,
-                boundary=boundary,
+                padding=padding,
             )
 
         new = func(
             ds[variable],
             multi_axis,
             metric_weighted=metric_weighted,
-            boundary=boundary,
+            padding=padding,
         )
         assert new.equals(expected)
 
@@ -228,27 +226,27 @@ class TestDerivatives:
             _run_single_derivative_test(grid, ax, ds[var], ds[dx])
 
 
-def _expected_result(da, metric, grid, dim, axes, funcname, boundary=None):
+def _expected_result(da, metric, grid, dim, axes, funcname, padding=None):
     """this is factoring out the expected output of metric aware operations"""
     if funcname == "integrate":
         expected = (da * metric).sum(dim)
     elif funcname == "average":
         expected = (da * metric).sum(dim) / metric.sum(dim)
     elif funcname == "cumint":
-        expected = grid.cumsum(da * metric, axes, boundary=boundary)
+        expected = grid.cumsum(da * metric, axes, padding=padding)
     else:
         raise ValueError(f"funcname {funcname} not recognized")
     return expected
 
 
 @pytest.mark.parametrize("funcname", ["integrate", "average", "cumint"])
-@pytest.mark.parametrize("boundary", ["fill", "extend"])
+@pytest.mark.parametrize("padding", ["fill", "extend"])
 @pytest.mark.parametrize(
     "periodic",
     [None, "True", "False", {"X": True, "Y": False}, {"X": False, "Y": True}],
 )
 class TestDifferentGridPositionsParametrized:
-    def test_bgrid(self, funcname, boundary, periodic):
+    def test_bgrid(self, funcname, padding, periodic):
         ds, coords, metrics = datasets_grid_metric("B")
         grid = Grid(
             ds,
@@ -259,10 +257,10 @@ class TestDifferentGridPositionsParametrized:
         )
 
         if funcname == "cumint":
-            # cumint needs a boundary
-            kwargs = dict(boundary=boundary)
+            # cumint needs a padding
+            kwargs = dict(padding=padding)
         else:
-            # integrate and average don't use the boundary input
+            # integrate and average don't use the padding input
             kwargs = dict()
 
         func = getattr(grid, funcname)
@@ -308,7 +306,7 @@ class TestDifferentGridPositionsParametrized:
             )
             assert_allclose(new, expected)
 
-    def test_cgrid(self, funcname, boundary, periodic):
+    def test_cgrid(self, funcname, padding, periodic):
         ds, coords, metrics = datasets_grid_metric("C")
         grid = Grid(
             ds,
@@ -319,10 +317,10 @@ class TestDifferentGridPositionsParametrized:
         )
 
         if funcname == "cumint":
-            # cumint needs a boundary
-            kwargs = dict(boundary=boundary)
+            # cumint needs a padding
+            kwargs = dict(padding=padding)
         else:
-            # integrate and average don't use the boundary input
+            # integrate and average don't use the padding input
             kwargs = dict()
 
         func = getattr(grid, funcname)
@@ -368,7 +366,7 @@ class TestDifferentGridPositionsParametrized:
             assert_allclose(new, expected)
 
     @pytest.mark.parametrize("axis", ["X", "Y", "Z"])
-    def test_missingaxis(self, axis, funcname, periodic, boundary):
+    def test_missingaxis(self, axis, funcname, periodic, padding):
         # Error should be raised if application axes include dimension not in datasets
 
         ds, coords, metrics = datasets_grid_metric("C")
@@ -393,8 +391,8 @@ class TestDifferentGridPositionsParametrized:
         func = getattr(grid, funcname)
 
         if funcname == "cumint":
-            # cumint needs a boundary
-            kwargs = dict(boundary=boundary)
+            # cumint needs a padding
+            kwargs = dict(padding=padding)
         else:
             kwargs = dict()
 
@@ -413,8 +411,8 @@ class TestDifferentGridPositionsParametrized:
             func = getattr(grid, funcname)
 
             if funcname == "cumint":
-                # cumint needs a boundary
-                kwargs = dict(boundary="fill")
+                # cumint needs a padding
+                kwargs = dict(padding="fill")
             else:
                 kwargs = dict()
 
@@ -424,7 +422,7 @@ class TestDifferentGridPositionsParametrized:
             with pytest.raises(KeyError, match="Did not find axis"):
                 func(ds.tracer, ("X", "Y"), **kwargs)
 
-    def test_metric_axes_missing_from_array(self, funcname, periodic, boundary):
+    def test_metric_axes_missing_from_array(self, funcname, periodic, padding):
         ds, coords, metrics = datasets_grid_metric("C")
         grid = Grid(
             ds,
@@ -435,8 +433,8 @@ class TestDifferentGridPositionsParametrized:
         )
 
         if funcname == "cumint":
-            # cumint needs a boundary
-            kwargs = dict(boundary="fill")
+            # cumint needs a padding
+            kwargs = dict(padding="fill")
         else:
             kwargs = dict()
 

--- a/xgcm/test/test_padding.py
+++ b/xgcm/test/test_padding.py
@@ -10,7 +10,7 @@ from xgcm.test.test_faceconnections import ds as ds_faces  # noqa: F401
 
 
 @pytest.mark.parametrize(
-    "boundary_width",
+    "padding_width",
     [
         {"X": (1, 1)},
         {"Y": (0, 1)},
@@ -19,14 +19,14 @@ from xgcm.test.test_faceconnections import ds as ds_faces  # noqa: F401
 )
 class TestPadding:
     @pytest.mark.parametrize("fill_value", [np.nan, 0, 1.5])
-    def test_padding_fill(self, boundary_width, fill_value):
+    def test_padding_fill(self, padding_width, fill_value):
         ds, coords, _ = datasets_grid_metric("C")
         grid = Grid(ds, coords=coords, autoparse_metadata=False)
         data = ds.tracer
 
         # iterate over all axes
         expected = data.copy(deep=True)
-        for ax, widths in boundary_width.items():
+        for ax, widths in padding_width.items():
             dim = grid._get_dims_from_axis(data, ax)[
                 0
             ]  # ? not entirely sure why this is a list
@@ -40,21 +40,21 @@ class TestPadding:
         result = pad(
             data,
             grid,
-            boundary="fill",
-            boundary_width=boundary_width,
+            padding="fill",
+            padding_width=padding_width,
             fill_value=fill_value,
             other_component=None,
         )
         xr.testing.assert_allclose(expected, result)
 
-    def test_padding_extend(self, boundary_width):
+    def test_padding_extend(self, padding_width):
         ds, coords, _ = datasets_grid_metric("C")
         grid = Grid(ds, coords=coords, autoparse_metadata=False)
         data = ds.tracer
 
         # iterate over all axes
         expected = data.copy(deep=True)
-        for ax, widths in boundary_width.items():
+        for ax, widths in padding_width.items():
             dim = grid._get_dims_from_axis(data, ax)[
                 0
             ]  # ? not entirely sure why this is a list
@@ -66,21 +66,21 @@ class TestPadding:
         result = pad(
             data,
             grid,
-            boundary="extend",
-            boundary_width=boundary_width,
+            padding="extend",
+            padding_width=padding_width,
             fill_value=None,
             other_component=None,
         )
         xr.testing.assert_allclose(expected, result)
 
-    def test_padding_periodic(self, boundary_width):
+    def test_padding_periodic(self, padding_width):
         ds, coords, _ = datasets_grid_metric("C")
         grid = Grid(ds, coords=coords, autoparse_metadata=False)
         data = ds.tracer
 
         # iterate over all axes
         expected = data.copy(deep=True)
-        for ax, widths in boundary_width.items():
+        for ax, widths in padding_width.items():
             dim = grid._get_dims_from_axis(data, ax)[
                 0
             ]  # ? not entirely sure why this is a list
@@ -92,14 +92,14 @@ class TestPadding:
         result = pad(
             data,
             grid,
-            boundary="periodic",
-            boundary_width=boundary_width,
+            padding="periodic",
+            padding_width=padding_width,
             fill_value=None,
             other_component=None,
         )
         xr.testing.assert_allclose(expected, result)
 
-    def test_padding_mixed(self, boundary_width):
+    def test_padding_mixed(self, padding_width):
         ds, coords, _ = datasets_grid_metric("C")
         grid = Grid(ds, coords=coords, autoparse_metadata=False)
         data = ds.tracer
@@ -112,7 +112,7 @@ class TestPadding:
 
         # iterate over all axes
         expected = data.copy(deep=True)
-        for ax, widths in boundary_width.items():
+        for ax, widths in padding_width.items():
             dim = grid._get_dims_from_axis(data, ax)[
                 0
             ]  # ? not entirely sure why this is a list
@@ -126,8 +126,8 @@ class TestPadding:
         result = pad(
             data,
             grid,
-            boundary=axis_padding_mapping,
-            boundary_width=boundary_width,
+            padding=axis_padding_mapping,
+            padding_width=padding_width,
             fill_value=None,
             other_component=None,
         )
@@ -138,7 +138,7 @@ class TestPadding:
 
 
 # Some helper functions for the connections padding
-def _prepad_right_left_same_axis(da, boundary_width, fill_value, x="x", y="y"):
+def _prepad_right_left_same_axis(da, padding_width, fill_value, x="x", y="y"):
     # Manually put together the data
     face_0 = da.isel(face=0)
     face_1 = da.isel(face=1)
@@ -146,8 +146,8 @@ def _prepad_right_left_same_axis(da, boundary_width, fill_value, x="x", y="y"):
     # pad on each side except on the connected side
     face_0_padded = face_0.pad(
         **{
-            x: (boundary_width["X"][0], 0),
-            y: (boundary_width["Y"][0], boundary_width["Y"][1]),
+            x: (padding_width["X"][0], 0),
+            y: (padding_width["Y"][0], padding_width["Y"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -155,8 +155,8 @@ def _prepad_right_left_same_axis(da, boundary_width, fill_value, x="x", y="y"):
 
     face_1_padded = face_1.pad(
         **{
-            x: (0, boundary_width["X"][1]),
-            y: (boundary_width["Y"][0], boundary_width["Y"][1]),
+            x: (0, padding_width["X"][1]),
+            y: (padding_width["Y"][0], padding_width["Y"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -164,7 +164,7 @@ def _prepad_right_left_same_axis(da, boundary_width, fill_value, x="x", y="y"):
     return face_0_padded, face_1_padded
 
 
-def _prepad_right_right_same_axis(da, boundary_width, fill_value, x="x", y="y"):
+def _prepad_right_right_same_axis(da, padding_width, fill_value, x="x", y="y"):
     # Manually put together the data
     face_0 = da.isel(face=0)
     face_1 = da.isel(face=1)
@@ -172,8 +172,8 @@ def _prepad_right_right_same_axis(da, boundary_width, fill_value, x="x", y="y"):
     # pad on each side except on the connected side
     face_0_padded = face_0.pad(
         **{
-            x: (boundary_width["X"][0], 0),
-            y: (boundary_width["Y"][0], boundary_width["Y"][1]),
+            x: (padding_width["X"][0], 0),
+            y: (padding_width["Y"][0], padding_width["Y"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -181,8 +181,8 @@ def _prepad_right_right_same_axis(da, boundary_width, fill_value, x="x", y="y"):
 
     face_1_padded = face_1.pad(
         **{
-            x: (boundary_width["X"][0], 0),
-            y: (boundary_width["Y"][0], boundary_width["Y"][1]),
+            x: (padding_width["X"][0], 0),
+            y: (padding_width["Y"][0], padding_width["Y"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -190,7 +190,7 @@ def _prepad_right_right_same_axis(da, boundary_width, fill_value, x="x", y="y"):
     return face_0_padded, face_1_padded
 
 
-def _prepad_right_left_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
+def _prepad_right_left_swap_axis(da, padding_width, fill_value, x="x", y="y"):
     # Manually put together the data
     face_0 = da.isel(face=0)
     face_1 = da.isel(face=1)
@@ -198,8 +198,8 @@ def _prepad_right_left_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
     # pad on each side except on the connected side
     face_0_padded = face_0.pad(
         **{
-            x: (boundary_width["X"][0], 0),
-            y: (boundary_width["Y"][0], boundary_width["Y"][1]),
+            x: (padding_width["X"][0], 0),
+            y: (padding_width["Y"][0], padding_width["Y"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -207,19 +207,19 @@ def _prepad_right_left_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
 
     face_1_padded = face_1.pad(
         **{
-            x: (boundary_width["X"][0], boundary_width["X"][1]),
-            y: (0, boundary_width["Y"][1]),
+            x: (padding_width["X"][0], padding_width["X"][1]),
+            y: (0, padding_width["Y"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
     )
 
     # Now pad each face according to the swapped axes, so that the connected slices match
-    # This is only relevant when the boundary width is not equal for all sides.
+    # This is only relevant when the padding width is not equal for all sides.
     face_0_padded_swapped = face_0.pad(
         **{
-            x: (boundary_width["Y"][0], 0),
-            y: (boundary_width["X"][1], boundary_width["X"][0]),
+            x: (padding_width["Y"][0], 0),
+            y: (padding_width["X"][1], padding_width["X"][0]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -227,8 +227,8 @@ def _prepad_right_left_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
 
     face_1_padded_swapped = face_1.pad(
         **{
-            x: (boundary_width["Y"][1], boundary_width["Y"][0]),
-            y: (0, boundary_width["X"][1]),
+            x: (padding_width["Y"][1], padding_width["Y"][0]),
+            y: (0, padding_width["X"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -236,7 +236,7 @@ def _prepad_right_left_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
     return face_0_padded, face_1_padded, face_0_padded_swapped, face_1_padded_swapped
 
 
-def _prepad_right_right_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
+def _prepad_right_right_swap_axis(da, padding_width, fill_value, x="x", y="y"):
     # Manually put together the data
     face_0 = da.isel(face=0)
     face_1 = da.isel(face=1)
@@ -244,8 +244,8 @@ def _prepad_right_right_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
     # pad on each side except on the connected side
     face_0_padded = face_0.pad(
         **{
-            x: (boundary_width["X"][0], 0),
-            y: (boundary_width["Y"][0], boundary_width["Y"][1]),
+            x: (padding_width["X"][0], 0),
+            y: (padding_width["Y"][0], padding_width["Y"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -253,8 +253,8 @@ def _prepad_right_right_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
 
     face_1_padded = face_1.pad(
         **{
-            x: (boundary_width["X"][0], boundary_width["X"][1]),
-            y: (boundary_width["Y"][0], 0),
+            x: (padding_width["X"][0], padding_width["X"][1]),
+            y: (padding_width["Y"][0], 0),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -264,8 +264,8 @@ def _prepad_right_right_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
     # This is only relevant when the boundary width is not equal for all sides.
     face_0_padded_swapped = face_0.pad(
         **{
-            x: (boundary_width["Y"][0], 0),
-            y: (boundary_width["X"][0], boundary_width["X"][1]),
+            x: (padding_width["Y"][0], 0),
+            y: (padding_width["X"][0], padding_width["X"][1]),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -273,8 +273,8 @@ def _prepad_right_right_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
 
     face_1_padded_swapped = face_1.pad(
         **{
-            x: (boundary_width["Y"][0], boundary_width["Y"][1]),
-            y: (boundary_width["X"][0], 0),
+            x: (padding_width["Y"][0], padding_width["Y"][1]),
+            y: (padding_width["X"][0], 0),
             "mode": "constant",
             "constant_values": fill_value,
         }
@@ -284,7 +284,7 @@ def _prepad_right_right_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
 
 @pytest.mark.parametrize("fill_value", [np.nan, 0])
 @pytest.mark.parametrize(
-    "boundary_width",
+    "padding_width",
     [
         {"X": (1, 1)},
         {"X": (1, 2)},
@@ -310,7 +310,7 @@ def _prepad_right_right_swap_axis(da, boundary_width, fill_value, x="x", y="y"):
 class TestPaddingFaceConnection:
     # TODO: Test that an error is raised if the boundary width exceeds the array shape.
     def test_face_connections_right_left_same_axis(
-        self, boundary_width, ds_faces, fill_value
+        self, padding_width, ds_faces, fill_value
     ):
         face_connections = {
             "face": {
@@ -322,7 +322,7 @@ class TestPaddingFaceConnection:
         data = ds_faces.data_c
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         # # restrict data here, so its easier to see the output
         # data = data.isel(y=slice(0, 2), x=slice(0, 2))
@@ -330,20 +330,20 @@ class TestPaddingFaceConnection:
 
         # prepad the arrays
         face_0_padded, face_1_padded = _prepad_right_left_same_axis(
-            data, boundary_width, fill_value
+            data, padding_width, fill_value
         )
 
         # then simply add the corresponding slice to each face according to the connection
         face_0_expected = xr.concat(
-            [face_0_padded, face_1_padded.isel(x=slice(0, boundary_width["X"][1]))],
+            [face_0_padded, face_1_padded.isel(x=slice(0, padding_width["X"][1]))],
             dim="x",
         )
         face_1_expected = xr.concat(
             [
                 face_0_padded.isel(
                     x=slice(
-                        -boundary_width["X"][0],
-                        None if boundary_width["X"][0] > 0 else 0,
+                        -padding_width["X"][0],
+                        None if padding_width["X"][0] > 0 else 0,
                         # this is a bit annoying. if the boundary width on this side is
                         # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
                     )
@@ -357,15 +357,15 @@ class TestPaddingFaceConnection:
         result = pad(
             data,
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component=None,
         )
         xr.testing.assert_allclose(result, expected)
 
     def test_face_connections_right_right_same_axis(
-        self, boundary_width, ds_faces, fill_value
+        self, padding_width, ds_faces, fill_value
     ):
         face_connections = {
             "face": {
@@ -377,7 +377,7 @@ class TestPaddingFaceConnection:
         data = ds_faces.data_c
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         # # restrict data here, so its easier to see the output
         # data = data.isel(y=slice(0, 2), x=slice(0, 2))
@@ -385,21 +385,21 @@ class TestPaddingFaceConnection:
 
         # prepad the arrays
         face_0_padded, face_1_padded = _prepad_right_right_same_axis(
-            data, boundary_width, fill_value
+            data, padding_width, fill_value
         )
 
         # Process the padded data
         face_0_addition = face_1_padded.isel(
             x=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
             )
         )
 
         face_1_addition = face_0_padded.isel(
             x=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
             )
         )
 
@@ -421,15 +421,15 @@ class TestPaddingFaceConnection:
         result = pad(
             data,
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component=None,
         )
         xr.testing.assert_allclose(result, expected)
 
     def test_face_connections_right_left_swap_axis(
-        self, boundary_width, ds_faces, fill_value
+        self, padding_width, ds_faces, fill_value
     ):
         face_connections = {
             "face": {
@@ -444,7 +444,7 @@ class TestPaddingFaceConnection:
         data = ds_faces.data_c
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         # restrict data here, so its easier to see the output
         data = data.isel(y=slice(0, 2), x=slice(0, 2))
@@ -455,12 +455,12 @@ class TestPaddingFaceConnection:
             face_1_padded,
             face_0_padded_swapped,
             face_1_padded_swapped,
-        ) = _prepad_right_left_swap_axis(data, boundary_width, fill_value)
+        ) = _prepad_right_left_swap_axis(data, padding_width, fill_value)
 
         # then simply add the corresponding slice to each face according to the connection
         # in this case we also need to rename them
 
-        face_0_addition = face_1_padded_swapped.isel(y=slice(0, boundary_width["X"][1]))
+        face_0_addition = face_1_padded_swapped.isel(y=slice(0, padding_width["X"][1]))
         # Flip both of these along the orthogonal axis
         face_0_addition = face_0_addition.isel(x=slice(None, None, -1))
         # In this case we need to rename the 'addition' dimensions
@@ -469,8 +469,8 @@ class TestPaddingFaceConnection:
         # Same steps for the other face
         face_1_addition = face_0_padded_swapped.isel(
             x=slice(
-                -boundary_width["Y"][0],
-                None if boundary_width["Y"][0] > 0 else 0,
+                -padding_width["Y"][0],
+                None if padding_width["Y"][0] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -496,18 +496,18 @@ class TestPaddingFaceConnection:
         result = pad(
             data,
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component=None,
         )
         xr.testing.assert_allclose(result, expected)
 
     def test_face_connections_right_right_swap_axis(
-        self, boundary_width, ds_faces, fill_value
+        self, padding_width, ds_faces, fill_value
     ):
         # set a default for boundary widths
-        boundary_width = {k: boundary_width.get(k, (0, 0)) for k in ["X", "Y"]}
+        padding_width = {k: padding_width.get(k, (0, 0)) for k in ["X", "Y"]}
 
         face_connections = {
             "face": {
@@ -522,7 +522,7 @@ class TestPaddingFaceConnection:
         data = ds_faces.data_c
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         # restrict data here, so its easier to see the output
         data = data.isel(y=slice(0, 3), x=slice(0, 3))
@@ -533,15 +533,15 @@ class TestPaddingFaceConnection:
             face_1_padded,
             face_0_padded_swapped,
             face_1_padded_swapped,
-        ) = _prepad_right_right_swap_axis(data, boundary_width, fill_value)
+        ) = _prepad_right_right_swap_axis(data, padding_width, fill_value)
 
         # then simply add the corresponding slice to each face according to the connection
         # in this case we also need to rename them
 
         face_0_addition = face_1_padded_swapped.isel(
             y=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -549,8 +549,8 @@ class TestPaddingFaceConnection:
         # Same steps for the other face
         face_1_addition = face_0_padded_swapped.isel(
             x=slice(
-                -boundary_width["Y"][1],
-                None if boundary_width["Y"][1] > 0 else 0,
+                -padding_width["Y"][1],
+                None if padding_width["Y"][1] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -577,15 +577,15 @@ class TestPaddingFaceConnection:
         result = pad(
             data,
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component=None,
         )
         xr.testing.assert_allclose(result, expected)
 
     def test_vector_face_connections_right_left_same_axis(
-        self, boundary_width, ds_faces, fill_value
+        self, padding_width, ds_faces, fill_value
     ):
         face_connections = {
             "face": {
@@ -598,7 +598,7 @@ class TestPaddingFaceConnection:
         v = ds_faces.v
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         # # restrict data here, so its easier to see the output
         # data = data.isel(y=slice(0, 2), x=slice(0, 2))
@@ -607,31 +607,31 @@ class TestPaddingFaceConnection:
 
         # prepad the arrays
         u_face_0_padded, u_face_1_padded = _prepad_right_left_same_axis(
-            u, boundary_width, fill_value, x="xl", y="y"
+            u, padding_width, fill_value, x="xl", y="y"
         )
         v_face_0_padded, v_face_1_padded = _prepad_right_left_same_axis(
             v,
-            boundary_width,
+            padding_width,
             fill_value,
             x="x",
             y="yl",
         )
 
         # Slice the appropriate portion of the source face to concat
-        u_face_0_addition = u_face_1_padded.isel(xl=slice(0, boundary_width["X"][1]))
+        u_face_0_addition = u_face_1_padded.isel(xl=slice(0, padding_width["X"][1]))
         u_face_1_addition = u_face_0_padded.isel(
             xl=slice(
-                -boundary_width["X"][0],
-                None if boundary_width["X"][0] > 0 else 0,
+                -padding_width["X"][0],
+                None if padding_width["X"][0] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
         )
-        v_face_0_addition = v_face_1_padded.isel(x=slice(0, boundary_width["X"][1]))
+        v_face_0_addition = v_face_1_padded.isel(x=slice(0, padding_width["X"][1]))
         v_face_1_addition = v_face_0_padded.isel(
             x=slice(
-                -boundary_width["X"][0],
-                None if boundary_width["X"][0] > 0 else 0,
+                -padding_width["X"][0],
+                None if padding_width["X"][0] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -663,8 +663,8 @@ class TestPaddingFaceConnection:
         u_result = pad(
             {"X": u},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"Y": v},
         )
@@ -674,15 +674,15 @@ class TestPaddingFaceConnection:
         v_result = pad(
             {"Y": v},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"X": u},
         )
         xr.testing.assert_allclose(v_result, v_expected)
 
     def test_vector_face_connections_right_right_same_axis(
-        self, boundary_width, ds_faces, fill_value
+        self, padding_width, ds_faces, fill_value
     ):
         face_connections = {
             "face": {
@@ -695,7 +695,7 @@ class TestPaddingFaceConnection:
         v = ds_faces.v
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         # # restrict data here, so its easier to see the output
         # data = data.isel(y=slice(0, 2), x=slice(0, 2))
@@ -703,11 +703,11 @@ class TestPaddingFaceConnection:
         v = v.reset_coords(drop=True).reset_index(v.dims, drop=True)
 
         u_face_0_padded, u_face_1_padded = _prepad_right_right_same_axis(
-            u, boundary_width, fill_value, x="xl", y="y"
+            u, padding_width, fill_value, x="xl", y="y"
         )
         v_face_0_padded, v_face_1_padded = _prepad_right_right_same_axis(
             v,
-            boundary_width,
+            padding_width,
             fill_value,
             x="x",
             y="yl",
@@ -716,26 +716,26 @@ class TestPaddingFaceConnection:
         # Slice the appropriate portion of the source face to concat
         u_face_0_addition = u_face_1_padded.isel(
             xl=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
             )
         )
         u_face_1_addition = u_face_0_padded.isel(
             xl=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
             )
         )
         v_face_0_addition = v_face_1_padded.isel(
             x=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
             )
         )
         v_face_1_addition = v_face_0_padded.isel(
             x=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
             )
         )
 
@@ -772,8 +772,8 @@ class TestPaddingFaceConnection:
         u_result = pad(
             {"X": u},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"Y": v},
         )
@@ -783,15 +783,15 @@ class TestPaddingFaceConnection:
         v_result = pad(
             {"Y": v},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"X": u},
         )
         xr.testing.assert_allclose(v_result, v_expected)
 
     def test_vector_face_connections_right_left_swap_axis(
-        self, boundary_width, ds_faces, fill_value
+        self, padding_width, ds_faces, fill_value
     ):
         face_connections = {
             "face": {
@@ -804,7 +804,7 @@ class TestPaddingFaceConnection:
         v = ds_faces.v
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         # # restrict data here, so its easier to see the output
         u = u.reset_coords(drop=True).reset_index(u.dims, drop=True)
@@ -815,18 +815,18 @@ class TestPaddingFaceConnection:
             u_face_1_padded,
             u_face_0_padded_swapped,
             u_face_1_padded_swapped,
-        ) = _prepad_right_left_swap_axis(u, boundary_width, fill_value, x="xl", y="y")
+        ) = _prepad_right_left_swap_axis(u, padding_width, fill_value, x="xl", y="y")
 
         (
             v_face_0_padded,
             v_face_1_padded,
             v_face_0_padded_swapped,
             v_face_1_padded_swapped,
-        ) = _prepad_right_left_swap_axis(v, boundary_width, fill_value, x="x", y="yl")
+        ) = _prepad_right_left_swap_axis(v, padding_width, fill_value, x="x", y="yl")
 
         # Put together the additions for each face
         u_face_0_addition = v_face_1_padded_swapped.isel(
-            yl=slice(0, boundary_width["X"][1])
+            yl=slice(0, padding_width["X"][1])
         ).rename({"x": "xl", "yl": "y"})
         # Tangential flip (u doesnt need sign change)
         u_face_0_addition = u_face_0_addition.isel(xl=slice(None, None, -1))
@@ -834,8 +834,8 @@ class TestPaddingFaceConnection:
 
         u_face_1_addition = v_face_0_padded_swapped.isel(
             x=slice(
-                -boundary_width["Y"][0],
-                None if boundary_width["Y"][0] > 0 else 0,
+                -padding_width["Y"][0],
+                None if padding_width["Y"][0] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -845,7 +845,7 @@ class TestPaddingFaceConnection:
 
         # now v (this one needs a sign change)
         v_face_0_addition = u_face_1_padded_swapped.isel(
-            y=slice(0, boundary_width["X"][1])
+            y=slice(0, padding_width["X"][1])
         ).rename({"xl": "x", "y": "yl"})
         # Tangential flip (v DOES need sign change)
         v_face_0_addition = -v_face_0_addition.isel(x=slice(None, None, -1))
@@ -853,8 +853,8 @@ class TestPaddingFaceConnection:
 
         v_face_1_addition = u_face_0_padded_swapped.isel(
             xl=slice(
-                -boundary_width["Y"][0],
-                None if boundary_width["Y"][0] > 0 else 0,
+                -padding_width["Y"][0],
+                None if padding_width["Y"][0] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -887,8 +887,8 @@ class TestPaddingFaceConnection:
         u_result = pad(
             {"X": u},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"Y": v},
         )
@@ -896,8 +896,8 @@ class TestPaddingFaceConnection:
         v_result = pad(
             {"Y": v},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"X": u},
         )
@@ -906,7 +906,7 @@ class TestPaddingFaceConnection:
         xr.testing.assert_allclose(v_result, v_expected)
 
     def test_vector_face_connections_right_right_swap_axis(
-        self, boundary_width, ds_faces, fill_value
+        self, padding_width, ds_faces, fill_value
     ):
         face_connections = {
             "face": {
@@ -919,7 +919,7 @@ class TestPaddingFaceConnection:
         v = ds_faces.v
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         # # restrict data here, so its easier to see the output
         u = u.reset_coords(drop=True).reset_index(u.dims, drop=True)
@@ -930,20 +930,20 @@ class TestPaddingFaceConnection:
             u_face_1_padded,
             u_face_0_padded_swapped,
             u_face_1_padded_swapped,
-        ) = _prepad_right_right_swap_axis(u, boundary_width, fill_value, x="xl", y="y")
+        ) = _prepad_right_right_swap_axis(u, padding_width, fill_value, x="xl", y="y")
 
         (
             v_face_0_padded,
             v_face_1_padded,
             v_face_0_padded_swapped,
             v_face_1_padded_swapped,
-        ) = _prepad_right_right_swap_axis(v, boundary_width, fill_value, x="x", y="yl")
+        ) = _prepad_right_right_swap_axis(v, padding_width, fill_value, x="x", y="yl")
 
         # Put together the additions for each face
         u_face_0_addition = v_face_1_padded_swapped.isel(
             yl=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -953,8 +953,8 @@ class TestPaddingFaceConnection:
 
         u_face_1_addition = v_face_0_padded_swapped.isel(
             x=slice(
-                -boundary_width["Y"][1],
-                None if boundary_width["Y"][1] > 0 else 0,
+                -padding_width["Y"][1],
+                None if padding_width["Y"][1] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -965,8 +965,8 @@ class TestPaddingFaceConnection:
         # now v (this one needs a sign change)
         v_face_0_addition = u_face_1_padded_swapped.isel(
             y=slice(
-                -boundary_width["X"][1],
-                None if boundary_width["X"][1] > 0 else 0,
+                -padding_width["X"][1],
+                None if padding_width["X"][1] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -977,8 +977,8 @@ class TestPaddingFaceConnection:
 
         v_face_1_addition = u_face_0_padded_swapped.isel(
             xl=slice(
-                -boundary_width["Y"][1],
-                None if boundary_width["Y"][1] > 0 else 0,
+                -padding_width["Y"][1],
+                None if padding_width["Y"][1] > 0 else 0,
                 # this is a bit annoying. if the boundary width on this side is
                 # 0 I want nothing to be padded. but slice(0,None) pads the whole array...
             )
@@ -1011,8 +1011,8 @@ class TestPaddingFaceConnection:
         u_result = pad(
             {"X": u},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"Y": v},
         )
@@ -1020,8 +1020,8 @@ class TestPaddingFaceConnection:
         v_result = pad(
             {"Y": v},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"X": u},
         )
@@ -1033,9 +1033,9 @@ class TestPaddingFaceConnection:
         reason="Figuring out how to preserve the indicies with padding is super hard.",
         strict=True,
     )
-    @pytest.mark.parametrize("boundary", ["constant", "wrap"])
+    @pytest.mark.parametrize("padding", ["constant", "wrap"])
     def test_vector_face_connections_coord_padding(
-        self, boundary_width, ds_faces, fill_value, boundary
+        self, padding_width, ds_faces, fill_value, padding
     ):
         # make sure that the complex padding acts like xarray.pad when it comes to dimension coordinates
         face_connections = {
@@ -1051,18 +1051,18 @@ class TestPaddingFaceConnection:
         v = ds_faces.v
 
         # fill in zeros for y boundary width if not given
-        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        padding_width["Y"] = padding_width.get("Y", (0, 0))
 
         padded_complex = pad(
             {"X": u},
             grid,
-            boundary_width=boundary_width,
-            boundary="fill",
+            padding_width=padding_width,
+            padding="fill",
             fill_value=fill_value,
             other_component={"Y": v},
         )
         padded_simple = u.pad(
-            {"xl": boundary_width["X"], "y": boundary_width["Y"]},
+            {"xl": padding_width["X"], "y": padding_width["Y"]},
             "constant",
             constant_values=fill_value,
         )  # TODO: add constant coord padding here once implemented in xarray.

--- a/xgcm/transform.py
+++ b/xgcm/transform.py
@@ -378,7 +378,7 @@ def transform(
     axis = grid.axes[axis_name]
 
     # raise error if axis is periodic
-    if axis.boundary == "periodic":
+    if axis.padding == "periodic":
         raise ValueError(
             "`transform` can only be used on axes that are non-periodic. Pass `periodic=False` to `xgcm.Grid`."
         )
@@ -492,7 +492,7 @@ def transform(
                 "The `target data` input is not located on the cell bounds. This method will continue with linear interpolation with repeated boundary values. For most accurate results provide values on cell bounds.",
                 UserWarning,
             )
-            target_data = grid.interp(target_data, axis_name, boundary="extend")
+            target_data = grid.interp(target_data, axis_name, padding="extend")
             # This seems to end up with chunks along the axis dimension.
             # Rechunk to keep xr.apply_func from complaining.
             # TODO: This should be made obsolete, when the internals are refactored using numba


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

This PR renames `boundary` to `padding` (and `boundary_width` to `padding_width`) across the codebase's public API according to the following deprecation guidance.

```md
When doing deprecations for renaming of variables, I want you to do the following.

## function signatures (also applies to class initialisers, and methods)

- Do the renaming of the variable in the function
- Provide a **kwargs in the function signature if not already there
- first item in the method should be checking if the old variable name is in the kwargs. If it is, raise a value error mentioning that the item is deprecated "Argument '{variable name}' has been renamed to ...". Then delete this old name from the kwargs dict.
- Add a comment `# TODO - remove deprecation handling`

## attributes

For class attributes:
- Do the renaming
- Add a property with the old name that when used raises the error "Attribute '{variable name}' has been renamed to ..."
- Add a comment `# TODO - remove deprecation handling`
```
I think this deprecation policy is the best way to go (it chooses explicit errors with very informative error messaging, rather than using deprecation cycles like in Xarray which would come with it significant maintenence burden with limited additional benefit).

I also updated the local variables/private API accordingly.

 - [x] Closes https://github.com/xgcm/xgcm/issues/678
 - [x] Tests added (added `test_deprecations.py`)
   - I only focussed here on the grid initialiser. Should I add the axis initialiser too? I imagine that testing for informative error messages across the entire API would be a bit overkill?
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
   - Let me know if this is sufficient, or if you want me to document all the public API that was changed

## pytest summary output

on master:

```
= 4179 passed, 2 skipped, 50 xfailed, 8 xpassed, 13344 warnings in 70.19s (0:01:10) =
```
on this PR:
```
= 4181 passed, 2 skipped, 50 xfailed, 8 xpassed, 13177 warnings in 71.45s (0:01:11) =
```
so the amount of warnings went down (likely due to fixing #678 

## LLM usage

I used AI in the following ways

- `claude 'Find all the public API functions, methods and classes that use "*boundary*" as either argument names or variable names. I want you to then document these in a separate file (note the file, and the item).'`
- Then I asked claude to do these renamings according to the deprecation policy above (without modifying the test suite at all or running it)
- Then I asked claude to update the test suite based on the test suite output

There was also quite a bit of manual iterations to help it along as claude missed a bunch of renamings etc.

Here is an 

<details><summary>AI generated summary of the renamings</summary>
<p>

# Summary: Renaming 'boundary' to 'padding' Across Public API

## Overview

All public API functions, methods, and classes have been updated to rename the `boundary` parameter to `padding`. Deprecation handling has been implemented according to the deprecation_guidance.md file.

## Changes Made

### 1. Class Constructors

#### `Grid.__init__()` (xgcm/grid.py:67-82)
- **Parameter renamed:** `boundary` → `padding`
- **Deprecation handling:** Added **kwargs and ValueError check for old parameter name
- **Internal updates:**
  - `boundary_dict` → `padding_dict`
  - Updated calls to `Axis()` constructor
  - Updated `__repr__()` method to use `axis.padding`

#### `Axis.__init__()` (xgcm/axis.py:28-69)
- **Parameter renamed:** `boundary` → `padding`
- **Deprecation handling:** Added **kwargs and ValueError check
- **Internal updates:**
  - `self._boundary` → `self._padding`
  - Updated `__repr__()` method

### 2. Class Properties

#### `Axis.boundary` (xgcm/axis.py:160-169)
- **New property:** `Axis.padding` returns `self._padding`
- **Deprecated property:** `Axis.boundary` raises AttributeError with migration message

### 3. Grid Methods

All Grid methods updated with deprecation handling:

1. **`Grid.interp_like()`** (line 547) - Parameter renamed, deprecation check added
2. **`Grid.apply_as_grid_ufunc()`** (line 766) - Parameter renamed, deprecation check added
3. **`Grid.interp()`** (line 850) - Docstring updated (uses **kwargs)
4. **`Grid.diff()`** (line 904) - Docstring updated (uses **kwargs)
5. **`Grid.min()`** (line 956) - Docstring updated (uses **kwargs)
6. **`Grid.max()`** (line 1009) - Docstring updated (uses **kwargs)
7. **`Grid.cumsum()`** (line 1075) - Parameter renamed, deprecation check added
8. **`Grid.interp_2d_vector()`** (line 1303) - Docstring updated (uses **kwargs)
9. **`Grid.derivative()`** (line 1322) - Docstring updated (uses **kwargs)
10. **`Grid.cumint()`** (line 1395) - Docstring updated (uses **kwargs)

### 4. Public Functions

#### `apply_as_grid_ufunc()` (xgcm/grid_ufunc.py:561)
- **Parameter renamed:** `boundary` → `padding`
- **Deprecation handling:** ValueError check added
- **Internal updates:** All internal function calls updated to use `padding`

#### `as_grid_ufunc()` (xgcm/grid_ufunc.py:478)
- **Decorator updated:** Checks for old parameter name in **kwargs
- **Allowed kwargs updated:** `"boundary"` → `"padding"`

### 5. GridUFunc Class (xgcm/grid_ufunc.py:323)

- **Attribute renamed:** `self.boundary` → `self.padding`
- **Deprecation handling:**
  - `__init__()`: ValueError check for old parameter name
  - `__call__()`: ValueError check for old parameter name
  - Property `boundary`: Raises AttributeError with migration message
- **`__repr__()` updated:** Shows `padding` instead of `boundary`

### 6. Internal Functions

#### `pad()` (xgcm/padding.py:347)
- **Parameter renamed:** `boundary` → `padding`
- **Deprecation handling:** ValueError check added
- **Docstring updated:** All references to "boundary" conditions changed to "padding"
- **Internal updates:** Calls to `grid._complete_user_kwargs_using_axis_defaults()` updated

#### `_pad_then_rechunk()` (xgcm/grid_ufunc.py:882)
- **Parameter renamed:** `boundary` → `padding`
- **Updated calls to `pad()`**

### 7. Documentation Updates

All docstrings have been updated throughout:
- `boundary` parameter → `padding` parameter
- "boundary conditions" → "padding conditions" (where appropriate)
- References to `boundary='fill'` → `padding='fill'`
- Deprecation warning message updated: Changed from suggesting `boundary='periodic'` to `padding='periodic'`

## Deprecation Pattern Used

All deprecations follow the pattern specified in deprecation_guidance.md:

### For Function Parameters:
```python
def some_function(padding=None, **kwargs):
    # TODO - remove deprecation handling
    if "boundary" in kwargs:
        raise ValueError(
            "Argument 'boundary' has been renamed to 'padding'. "
            "Please use 'padding' instead."
        )
    # ... rest of function
```

### For Class Attributes:
```python
@property
def boundary(self):
    # TODO - remove deprecation handling
    raise AttributeError(
        "Attribute 'boundary' has been renamed to 'padding'. "
        "Please use 'padding' instead."
    )
```

## Files Modified

1. `xgcm/grid.py` - Grid class and all its methods
2. `xgcm/axis.py` - Axis class constructor and properties
3. `xgcm/grid_ufunc.py` - apply_as_grid_ufunc, as_grid_ufunc, GridUFunc class
4. `xgcm/padding.py` - pad() function and internal references

## Cleanup Tasks for Future

All deprecation handling code is marked with `# TODO - remove deprecation handling` comments for easy identification when the deprecation period ends.

## Testing Recommendations

Users should:
1. Update all calls from `boundary=` to `padding=` in their code
2. Update all references to `.boundary` attribute to `.padding`
3. Test that the new parameter names work correctly
4. Verify that using old parameter names raises clear error messages

## Note on Internal Variable Names

Some internal variable names still contain "boundary_width" (e.g., `boundary_width_real_axes`). These were not renamed as they are internal implementation details and do not affect the public API. The guidance document specified renaming only in the public API.


</p>
</details> 