### PR TITLE
Improve xgcm import speed

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -36,6 +36,9 @@
 - Migrate development workflow to Pixi ([#691](https://github.com/xgcm/xgcm/pull/691))
   By [Nick Hodgskin](https://github.com/VeckoTheGecko).
 
+- Improve xgcm import speed by lazy-loading the transform module, reducing import time from 3.4s to 0.8s ([#697](https://github.com/xgcm/xgcm/pull/697))
+  By [Nick Hodgskin](https://github.com/VeckoTheGecko).
+
 ### Documentation
 
 - Migrate documentation to mkdocs ([#691](https://github.com/xgcm/xgcm/pull/691))

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -35,13 +35,6 @@ from .grid_ufunc import (
 from .metrics import iterate_axis_combinations
 from .padding import pad
 
-try:
-    import numba  # type: ignore
-
-    from .transform import transform
-except ImportError:
-    numba = None
-
 from typing import Literal
 
 
@@ -1547,8 +1540,9 @@ class Grid:
 
 
         """
-        # check optional numba dependency
-        if numba is None:
+        try:
+            from .transform import transform
+        except ImportError:
             raise ImportError(
                 "The transform functionality of xgcm requires numba. Install using `conda install numba`."
             )


### PR DESCRIPTION
xgcm spent 2.5s importing the transform module. Since it doesn't need to be eagerly imported, switching this to be lazily imported results in a significant speedup (from 3.4s to 0.8s).

I used `python -X importtime -c 'import xarray' 2> tuna.log && tuna tuna.log` where tuna is https://pypi.org/project/tuna/ . Note that you need to run the import twice to test from a warm cache (the first time after Pixi building the environment will create the `.pyc` files, then subsequent times will be faster).

Here's a before and after


<img width="2549" height="1070" alt="image" src="https://github.com/user-attachments/assets/5920e41d-484b-47b2-8d53-64f192308da9" />


<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes None
 - [x] Tests added (NA)
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
 - [x] New functions/methods are listed in `api.rst`
