### PR TITLE
Bugfix vector diff/interp on grids with face connections

### DIFF
--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -942,7 +942,8 @@ def _map_func_over_core_dims(
     # Need to transpose the numpy axis arguments to leave core dims at end
     # else they won't match up inside mapped_func after xr.apply_ufunc does its transposition
     transposed_original_args = [
-        arg.transpose(..., *in_core_dims[i]) for i, arg in enumerate(original_args)
+        _maybe_unpack_vector_component(arg).transpose(..., *in_core_dims[i])
+        for i, arg in enumerate(original_args)
     ]
 
     boundary_width_per_numpy_axis = {
@@ -1020,7 +1021,8 @@ def _rechunk_to_merge_in_boundary_chunks(
 
     rechunked_padded_args = []
     for padded_arg, original_arg in zip(padded_args, original_args):
-        original_arg_chunks = original_arg.variable.chunksizes
+        original_arg_da = _maybe_unpack_vector_component(original_arg)
+        original_arg_chunks = original_arg_da.variable.chunksizes
         merged_boundary_chunks = _get_chunk_pattern_for_merging_boundary(
             grid,
             padded_arg,

--- a/xgcm/test/test_faceconnections.py
+++ b/xgcm/test/test_faceconnections.py
@@ -349,6 +349,43 @@ def test_vector_diff_interp_connected_grid_x_to_y_dask(
         )
 
 
+@pytest.mark.xfail(
+    raises=ValueError,
+    reason="map_overlap path does not support face-connection vectors with a "
+    "chunked core dim, see https://github.com/xgcm/xgcm/issues/708",
+)
+def test_vector_diff_connected_grid_x_to_y_dask_multichunk(
+    ds, ds_face_connections_x_to_y
+):
+    """Known failure: see https://github.com/xgcm/xgcm/issues/708.
+
+    When a vector component has more than one chunk along its core dimension,
+    ``_1d_grid_ufunc_dispatch`` routes through the ``map_overlap`` path
+    (``_map_func_over_core_dims``). Face-connection padding changes the number
+    of blocks along the core dim, but the ``adjust_chunks`` spec handed to dask
+    still expects the pre-pad block count, so the computation fails with
+    ``ValueError: Dimension 0 has 2 blocks, adjust_chunks specified with 1
+    blocks``. Unlike #704 (fixed, single-chunk case), this path is not yet
+    supported. When this starts passing, fix #708 and remove the xfail marker.
+    """
+    pytest.importorskip("dask")
+
+    grid = Grid(ds, face_connections=ds_face_connections_x_to_y)
+
+    # >1 chunk along the core dim flips the dispatch onto the map_overlap path.
+    u = ds.u.chunk({"xl": 10})
+    v = ds.v.chunk({"yl": 10})
+
+    vector_out = grid.diff_2d_vector(
+        {"X": u, "Y": v},
+        to="center",
+        boundary="fill",
+        fill_value=100,
+    )
+    # The failure surfaces on compute (lazy graph construction may succeed).
+    vector_out["X"].compute()
+
+
 def test_create_cubed_sphere_grid(cs, cubed_sphere_connections):
     _ = Grid(cs, face_connections=cubed_sphere_connections)
 

--- a/xgcm/test/test_faceconnections.py
+++ b/xgcm/test/test_faceconnections.py
@@ -295,6 +295,60 @@ def test_vector_diff_interp_connected_grid_x_to_y(
         _ = grid.interp_2d_vector({"X": ds.v, "Y": ds.u}, boundary="fill")
 
 
+@pytest.mark.parametrize("method", ["interp_2d_vector", "diff_2d_vector"])
+def test_vector_diff_interp_connected_grid_x_to_y_dask(
+    ds, ds_face_connections_x_to_y, method
+):
+    """Regression test for https://github.com/xgcm/xgcm/issues/704.
+
+    When the vector components are dask-backed, padding splits the core
+    dimension into boundary chunks, so the operation goes through
+    ``_rechunk_to_merge_in_boundary_chunks``. That helper used to assume the
+    argument was always a ``DataArray`` and raised
+    ``AttributeError: 'dict' object has no attribute 'variable'`` when handed
+    the ``{"X": u}`` vector-component dict (see the traceback in #704). Here we
+    keep the inputs lazy (single chunk per core dim) so the result must match
+    the numpy path exactly.
+    """
+    pytest.importorskip("dask")
+
+    grid = Grid(ds, face_connections=ds_face_connections_x_to_y)
+
+    # Keep the components lazy with a single chunk per core dim. This mirrors
+    # the #704 scenario: map_overlap stays False, but padding still chunks the
+    # core dim, exercising _rechunk_to_merge_in_boundary_chunks.
+    u = ds.u.chunk()
+    v = ds.v.chunk()
+
+    vector_out = getattr(grid, method)(
+        {"X": u, "Y": v},
+        to="center",
+        boundary="fill",
+        fill_value=100,
+    )
+    u_c = vector_out["X"]
+
+    # The result should stay on the dask path.
+    assert u_c.chunks is not None
+
+    # Values must match the numpy path: first point is normal, last point picks
+    # up the rotated neighbour across the face connection.
+    if method == "interp_2d_vector":
+        np.testing.assert_allclose(
+            u_c.data[0, 0, :], 0.5 * (ds.u.data[0, 0, :] + ds.u.data[0, 1, :])
+        )
+        np.testing.assert_allclose(
+            u_c.data[0, -1, :], 0.5 * (ds.u.data[0, -1, :] + ds.v.data[1, ::-1, 0])
+        )
+    else:
+        np.testing.assert_allclose(
+            u_c.data[0, 0, :], ds.u.data[0, 1, :] - ds.u.data[0, 0, :]
+        )
+        np.testing.assert_allclose(
+            u_c.data[0, -1, :], -ds.u.data[0, -1, :] + ds.v.data[1, ::-1, 0]
+        )
+
+
 def test_create_cubed_sphere_grid(cs, cubed_sphere_connections):
     _ = Grid(cs, face_connections=cubed_sphere_connections)
 


### PR DESCRIPTION
On grids with face connections, vector components require calls like `grid.diff({"X": U}, "X", other_component={"Y": V})` in order to full utilize the grid information. At the moment, this is **not** equivalent to `grid.diff(U, "X", other_component={"Y": V}).` As I understand it, passing `{"X": U} `tells xgcm that `U` is a vector component, which allows it to use `V` when padding across connected faces.

`_map_func_over_core_dims` in `grid_ufunc.py` was still assuming that the input was always a DataArray (instead of a dict, i.e., `{"X": U}`) when (1) setting up the chunked overlap step, and  (2) when reading chunk sizes after padding. This change unwraps the DataArray from that one-item dictionary before those steps, so vector diff/interp for vector components behaves correctly on grids with face connections instead of failing with `AttributeError: 'dict' object has no attribute 'variable'`.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #704 