### PR TITLE
Fix vector diff/interp on face-connection grids with a chunked core dim (map_overlap path)

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -46,6 +46,14 @@
 
 ### Bugfixes
 
+- Fix `diff_2d_vector`/`interp_2d_vector` (and the equivalent vector-component `Grid.diff`/`Grid.interp`)
+  on grids with face connections when a vector component is a dask array chunked into more than one chunk
+  along its core dimension. The `map_overlap` path now derives the output chunk spec from the padded,
+  rechunked array, so face-connection padding that rechunks non-core dimensions no longer raises
+  `ValueError: Dimension 0 has 2 blocks, adjust_chunks specified with 1 blocks`
+  ([#708](https://github.com/xgcm/xgcm/issues/708)).
+  By [Henri Drake](https://github.com/hdrake).
+
 - Fix bug in `xgcm.transform.transform` that violated tracer conservation when using conservative interpolation in the presence of nans. ([#635](https://github.com/xgcm/xgcm/pull/635))
   By [Julius Busecke](https://github.com/jbusecke).
 - Fix bug in `xgcm.padding._maybe_rename_grid_positions` where dimensions were assumed to have coordinate

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -942,7 +942,8 @@ def _map_func_over_core_dims(
     # Need to transpose the numpy axis arguments to leave core dims at end
     # else they won't match up inside mapped_func after xr.apply_ufunc does its transposition
     transposed_original_args = [
-        arg.transpose(..., *in_core_dims[i]) for i, arg in enumerate(original_args)
+        _maybe_unpack_vector_component(arg).transpose(..., *in_core_dims[i])
+        for i, arg in enumerate(original_args)
     ]
 
     boundary_width_per_numpy_axis = {
@@ -1020,7 +1021,8 @@ def _rechunk_to_merge_in_boundary_chunks(
 
     rechunked_padded_args = []
     for padded_arg, original_arg in zip(padded_args, original_args):
-        original_arg_chunks = original_arg.variable.chunksizes
+        original_arg_da = _maybe_unpack_vector_component(original_arg)
+        original_arg_chunks = original_arg_da.variable.chunksizes
         merged_boundary_chunks = _get_chunk_pattern_for_merging_boundary(
             grid,
             padded_arg,

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -959,14 +959,31 @@ def _map_func_over_core_dims(
         """This implicitly crystallises the order of the given mapping"""
         return tuple(sizes.values())
 
-    # Our rechunking means dask.map_overlap needs to be explicitly told what chunks output should have
-    # But in this case output chunks are the same as input chunks
-    # (as we disallowed axis positions for which this is not the case)
+    # Our rechunking means dask.map_overlap needs to be explicitly told what chunks output should have.
+    # Along the core dims the output chunks match the *original* (pre-pad) chunks, because the ufunc
+    # consumes the boundary padding (we disallowed axis positions for which this is not the case).
     original_chunksizes = [arg.variable.chunksizes for arg in transposed_original_args]
     # TODO first argument only because map_overlap can't handle multiple return values (I think)
     true_chunksizes = original_chunksizes[0]
     # dask.map_overlap needs chunks in terms of axis number, not axis name (i.e. (chunks, ...), not {str: chunks})
     true_chunksizes_per_numpy_axis = _dict_to_numbered_axes(true_chunksizes)
+
+    # The core dims are the only axes whose chunks are deliberately changed (by padding + rechunking).
+    core_numpy_axes = set(boundary_width_per_numpy_axis)
+
+    def _output_chunks_per_numpy_axis(arg):
+        # On grids with face connections, padding a vector component pulls in data from a connected
+        # face, which can force dask to rechunk *non-core* dims (e.g. splitting the face dim). The
+        # number of blocks per non-core dim must match the array actually handed to map_overlap, so
+        # we read those from the (padded, rechunked) input rather than the original. Core dims keep
+        # their original chunks, since the ufunc trims the padding back to the unpadded size.
+        actual_chunks = arg.chunks
+        return tuple(
+            true_chunksizes_per_numpy_axis[axis]
+            if axis in core_numpy_axes
+            else actual_chunks[axis]
+            for axis in range(arg.ndim)
+        )
 
     # (we don't need a separate code path using bare map_blocks if boundary_widths are zero because map_overlap just
     # calls map_blocks automatically in that scenario)
@@ -979,7 +996,7 @@ def _map_func_over_core_dims(
             boundary="none",
             trim=False,
             meta=np.array([], dtype=out_dtypes[0]),
-            chunks=true_chunksizes_per_numpy_axis,
+            chunks=_output_chunks_per_numpy_axis(a[0]),
         )
 
     return mapped_func

--- a/xgcm/test/test_faceconnections.py
+++ b/xgcm/test/test_faceconnections.py
@@ -349,24 +349,23 @@ def test_vector_diff_interp_connected_grid_x_to_y_dask(
         )
 
 
-@pytest.mark.xfail(
-    raises=ValueError,
-    reason="map_overlap path does not support face-connection vectors with a "
-    "chunked core dim, see https://github.com/xgcm/xgcm/issues/708",
-)
-def test_vector_diff_connected_grid_x_to_y_dask_multichunk(
-    ds, ds_face_connections_x_to_y
+@pytest.mark.parametrize("method", ["interp_2d_vector", "diff_2d_vector"])
+def test_vector_diff_interp_connected_grid_x_to_y_dask_multichunk(
+    ds, ds_face_connections_x_to_y, method
 ):
-    """Known failure: see https://github.com/xgcm/xgcm/issues/708.
+    """Regression test for https://github.com/xgcm/xgcm/issues/708.
 
     When a vector component has more than one chunk along its core dimension,
     ``_1d_grid_ufunc_dispatch`` routes through the ``map_overlap`` path
-    (``_map_func_over_core_dims``). Face-connection padding changes the number
-    of blocks along the core dim, but the ``adjust_chunks`` spec handed to dask
-    still expects the pre-pad block count, so the computation fails with
-    ``ValueError: Dimension 0 has 2 blocks, adjust_chunks specified with 1
-    blocks``. Unlike #704 (fixed, single-chunk case), this path is not yet
-    supported. When this starts passing, fix #708 and remove the xfail marker.
+    (``_map_func_over_core_dims``) instead of the single-chunk path exercised by
+    ``test_vector_diff_interp_connected_grid_x_to_y_dask`` (#704). Padding a
+    vector component across a face connection pulls in data from the connected
+    face, which forces dask to rechunk the *non-core* dims (e.g. splitting the
+    face dim). The ``adjust_chunks`` spec handed to dask used to be derived from
+    the pre-pad array, so it still expected the original block count and the
+    computation failed with ``ValueError: Dimension 0 has 2 blocks,
+    adjust_chunks specified with 1 blocks``. The result must now match the numpy
+    path exactly.
     """
     pytest.importorskip("dask")
 
@@ -376,14 +375,34 @@ def test_vector_diff_connected_grid_x_to_y_dask_multichunk(
     u = ds.u.chunk({"xl": 10})
     v = ds.v.chunk({"yl": 10})
 
-    vector_out = grid.diff_2d_vector(
+    vector_out = getattr(grid, method)(
         {"X": u, "Y": v},
         to="center",
         boundary="fill",
         fill_value=100,
     )
-    # The failure surfaces on compute (lazy graph construction may succeed).
-    vector_out["X"].compute()
+    u_c = vector_out["X"]
+
+    # The result should stay on the dask path, with the core dim still chunked.
+    assert u_c.chunks is not None
+    assert len(u_c.variable.chunksizes["x"]) > 1
+
+    # Values must match the numpy path: first point is normal, last point picks
+    # up the rotated neighbour across the face connection.
+    if method == "interp_2d_vector":
+        np.testing.assert_allclose(
+            u_c.data[0, 0, :], 0.5 * (ds.u.data[0, 0, :] + ds.u.data[0, 1, :])
+        )
+        np.testing.assert_allclose(
+            u_c.data[0, -1, :], 0.5 * (ds.u.data[0, -1, :] + ds.v.data[1, ::-1, 0])
+        )
+    else:
+        np.testing.assert_allclose(
+            u_c.data[0, 0, :], ds.u.data[0, 1, :] - ds.u.data[0, 0, :]
+        )
+        np.testing.assert_allclose(
+            u_c.data[0, -1, :], -ds.u.data[0, -1, :] + ds.v.data[1, ::-1, 0]
+        )
 
 
 def test_create_cubed_sphere_grid(cs, cubed_sphere_connections):

--- a/xgcm/test/test_faceconnections.py
+++ b/xgcm/test/test_faceconnections.py
@@ -349,6 +349,43 @@ def test_vector_diff_interp_connected_grid_x_to_y_dask(
         )
 
 
+@pytest.mark.xfail(
+    raises=ValueError,
+    reason="map_overlap path does not support face-connection vectors with a "
+    "chunked core dim, see https://github.com/xgcm/xgcm/issues/708",
+)
+def test_vector_diff_connected_grid_x_to_y_dask_multichunk(
+    ds, ds_face_connections_x_to_y
+):
+    """Known failure: see https://github.com/xgcm/xgcm/issues/708.
+
+    When a vector component has more than one chunk along its core dimension,
+    ``_1d_grid_ufunc_dispatch`` routes through the ``map_overlap`` path
+    (``_map_func_over_core_dims``). Face-connection padding changes the number
+    of blocks along the core dim, but the ``adjust_chunks`` spec handed to dask
+    still expects the pre-pad block count, so the computation fails with
+    ``ValueError: Dimension 0 has 2 blocks, adjust_chunks specified with 1
+    blocks``. Unlike #704 (fixed, single-chunk case), this path is not yet
+    supported. When this starts passing, fix #708 and remove the xfail marker.
+    """
+    pytest.importorskip("dask")
+
+    grid = Grid(ds, face_connections=ds_face_connections_x_to_y)
+
+    # >1 chunk along the core dim flips the dispatch onto the map_overlap path.
+    u = ds.u.chunk({"xl": 10})
+    v = ds.v.chunk({"yl": 10})
+
+    vector_out = grid.diff_2d_vector(
+        {"X": u, "Y": v},
+        to="center",
+        boundary="fill",
+        fill_value=100,
+    )
+    # The failure surfaces on compute (lazy graph construction may succeed).
+    vector_out["X"].compute()
+
+
 def test_create_cubed_sphere_grid(cs, cubed_sphere_connections):
     _ = Grid(cs, face_connections=cubed_sphere_connections)
 

--- a/xgcm/test/test_faceconnections.py
+++ b/xgcm/test/test_faceconnections.py
@@ -295,6 +295,60 @@ def test_vector_diff_interp_connected_grid_x_to_y(
         _ = grid.interp_2d_vector({"X": ds.v, "Y": ds.u}, boundary="fill")
 
 
+@pytest.mark.parametrize("method", ["interp_2d_vector", "diff_2d_vector"])
+def test_vector_diff_interp_connected_grid_x_to_y_dask(
+    ds, ds_face_connections_x_to_y, method
+):
+    """Regression test for https://github.com/xgcm/xgcm/issues/704.
+
+    When the vector components are dask-backed, padding splits the core
+    dimension into boundary chunks, so the operation goes through
+    ``_rechunk_to_merge_in_boundary_chunks``. That helper used to assume the
+    argument was always a ``DataArray`` and raised
+    ``AttributeError: 'dict' object has no attribute 'variable'`` when handed
+    the ``{"X": u}`` vector-component dict (see the traceback in #704). Here we
+    keep the inputs lazy (single chunk per core dim) so the result must match
+    the numpy path exactly.
+    """
+    pytest.importorskip("dask")
+
+    grid = Grid(ds, face_connections=ds_face_connections_x_to_y)
+
+    # Keep the components lazy with a single chunk per core dim. This mirrors
+    # the #704 scenario: map_overlap stays False, but padding still chunks the
+    # core dim, exercising _rechunk_to_merge_in_boundary_chunks.
+    u = ds.u.chunk()
+    v = ds.v.chunk()
+
+    vector_out = getattr(grid, method)(
+        {"X": u, "Y": v},
+        to="center",
+        boundary="fill",
+        fill_value=100,
+    )
+    u_c = vector_out["X"]
+
+    # The result should stay on the dask path.
+    assert u_c.chunks is not None
+
+    # Values must match the numpy path: first point is normal, last point picks
+    # up the rotated neighbour across the face connection.
+    if method == "interp_2d_vector":
+        np.testing.assert_allclose(
+            u_c.data[0, 0, :], 0.5 * (ds.u.data[0, 0, :] + ds.u.data[0, 1, :])
+        )
+        np.testing.assert_allclose(
+            u_c.data[0, -1, :], 0.5 * (ds.u.data[0, -1, :] + ds.v.data[1, ::-1, 0])
+        )
+    else:
+        np.testing.assert_allclose(
+            u_c.data[0, 0, :], ds.u.data[0, 1, :] - ds.u.data[0, 0, :]
+        )
+        np.testing.assert_allclose(
+            u_c.data[0, -1, :], -ds.u.data[0, -1, :] + ds.v.data[1, ::-1, 0]
+        )
+
+
 def test_create_cubed_sphere_grid(cs, cubed_sphere_connections):
     _ = Grid(cs, face_connections=cubed_sphere_connections)
 


### PR DESCRIPTION
## What this fixes

Closes #708.

`diff_2d_vector` / `interp_2d_vector` (and the equivalent vector-component `grid.diff` / `grid.interp` with `other_component`) on a grid **with face connections** failed when a vector component was a dask array chunked into **more than one chunk along its core dimension**.

With `>1` core-dim chunk, `Grid._1d_grid_ufunc_dispatch` sets `map_overlap=True`, routing through `_map_func_over_core_dims`. Padding a vector component across a face connection pulls in data from the connected face, which forces dask to rechunk the **non-core** dims (e.g. splitting the `face` dim from one block into several). The `adjust_chunks` spec handed to dask's `map_overlap`/`blockwise` was derived from the *pre-pad* array, so it still expected the original block count and the computation failed with:

```
ValueError: Dimension 0 has 2 blocks, adjust_chunks specified with 1 blocks
```

## The fix

Derive the output `chunks` spec from the array actually handed to `map_overlap` rather than the original:

- **core dims** keep their original (pre-pad) chunks — the ufunc consumes/trims the boundary padding back to the unpadded size (axis positions where this isn't true are already disallowed);
- **every other dim** uses the real block structure of the padded, rechunked input, so face-connection padding that rechunks non-core dimensions no longer trips the block-count check.

## Testing

- Flipped the previously-`xfail`ed regression test (`test_vector_diff_interp_connected_grid_x_to_y_dask_multichunk`, added for this in #705) into a passing test, now parametrized over both `diff_2d_vector` and `interp_2d_vector` and asserting the dask result matches the numpy path exactly (including the rotated neighbour across the face connection).
- Full test suite passes locally (`4183 passed`).

## Note on stacking

This builds on **#705** (closes #704), which is the prerequisite fix for the single-chunk case and which added the `xfail` test this PR resolves. #705 is not yet merged, so this branch includes its commits; merging this PR therefore also incorporates #705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)