### PR TITLE
Respect fill_value set on the as_grid_ufunc decorator (fixes #652)

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -46,6 +46,13 @@
 
 ### Bugfixes
 
+- Respect the `fill_value` bound on the `@as_grid_ufunc` decorator (or passed to `GridUFunc`). It was
+  silently dropped in `GridUFunc.__call__` — only a call-time `fill_value` took effect, so a bound value
+  fell through to the `apply_as_grid_ufunc` default of `0`. The bound value is now forwarded (and still
+  overridable at call time), mirroring the other bound boundary kwargs
+  ([#652](https://github.com/xgcm/xgcm/issues/652), [#710](https://github.com/xgcm/xgcm/pull/710)).
+  By [Vincent Gao](https://github.com/gaoflow).
+
 - Fix `diff_2d_vector`/`interp_2d_vector` (and the equivalent vector-component `Grid.diff`/`Grid.interp`)
   on grids with face connections when a vector component is a dask array chunked into more than one chunk
   along its core dimension. The `map_overlap` path now derives the output chunk spec from the padded,

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -457,6 +457,7 @@ class GridUFunc:
         **kwargs,
     ):
         boundary = kwargs.pop("boundary", self.boundary)
+        fill_value = kwargs.pop("fill_value", self.fill_value)
         dask = kwargs.pop("dask", self.dask)
         map_overlap = kwargs.pop("map_overlap", self.map_overlap)
         pad_before_func = kwargs.pop("pad_before_func", self.pad_before_func)
@@ -468,6 +469,7 @@ class GridUFunc:
             signature=self.signature,
             boundary_width=self.boundary_width,
             boundary=boundary,
+            fill_value=fill_value,
             dask=dask,
             map_overlap=map_overlap,
             pad_before_func=pad_before_func,

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -1074,6 +1074,36 @@ class TestBoundary:
         expected = grid._ds.lat_g.copy(data=interped_arr_padded_with_one)
         assert_equal(result, expected)
 
+    def test_fill_value_from_decorator(self):
+        # A non-zero fill_value set on the decorator must be used, not silently
+        # ignored in favour of the default of 0 (GH #652). It must also still be
+        # overridable at call time.
+        def interp(a):
+            return 0.5 * (a[..., :-1] + a[..., 1:])
+
+        @as_grid_ufunc(
+            signature="(X:center)->(X:left)",
+            boundary_width={"X": (1, 0)},
+            boundary="fill",
+            fill_value=10,
+        )
+        def interp_center_to_left(a):
+            return interp(a)
+
+        grid = create_1d_test_grid("lat")
+        arr = np.arange(9)
+        da = grid._ds.lat_c.copy(data=arr)
+
+        # fill_value=10 from the decorator must be honoured (would pad with 0 if ignored)
+        result = interp_center_to_left(grid, da, axis=[["lat"]])
+        expected = grid._ds.lat_g.copy(data=interp(np.concatenate([[10], arr])))
+        assert_equal(result, expected)
+
+        # a call-time fill_value still overrides the decorator value
+        result = interp_center_to_left(grid, da, axis=[["lat"]], fill_value=1)
+        expected = grid._ds.lat_g.copy(data=interp(np.concatenate([[1], arr])))
+        assert_equal(result, expected)
+
 
 # TODO tests for handling dask in gri.diff etc. should eventually live in test_grid.py
 class TestMapOverlapGridops:


### PR DESCRIPTION
Fixes #652.

## The bug

A `fill_value` supplied to the `@as_grid_ufunc(...)` decorator (or to `GridUFunc(...)`) is silently ignored. Only a `fill_value` passed at *call time* takes effect; the bound value falls through to `apply_as_grid_ufunc`'s default of `0`.

In `GridUFunc.__call__`, the other bound boundary kwargs are read back from `kwargs` with the instance attribute as the fallback:

```python
boundary = kwargs.pop("boundary", self.boundary)
dask = kwargs.pop("dask", self.dask)
map_overlap = kwargs.pop("map_overlap", self.map_overlap)
pad_before_func = kwargs.pop("pad_before_func", self.pad_before_func)
```

…but `fill_value` was missing from this list, so `self.fill_value` (set in `__init__`) was never forwarded.

## Reproduction

```python
import numpy as np
from xgcm import Grid
from xgcm.grid_ufunc import as_grid_ufunc

# build a simple 1D center->left grid (omitted for brevity), then:
@as_grid_ufunc(signature="(X:center)->(X:left)",
               boundary_width={"X": (1, 0)},
               boundary="fill", fill_value=10)
def interp_center_to_left(a):
    return 0.5 * (a[..., :-1] + a[..., 1:])

# Before this fix the left-most cell is padded with 0 (the default),
# not 10, so the boundary result is wrong. Passing fill_value=10 at
# call time worked, proving the decorator value was being dropped.
```

## The fix

Read `fill_value` from `kwargs` with `self.fill_value` as the fallback, mirroring the other bound boundary kwargs, and forward it to `apply_as_grid_ufunc`.

## Verification

- New regression test `TestBoundary::test_fill_value_from_decorator` asserts a non-zero decorator `fill_value` is honoured and is still overridable at call time. It **fails on `master`** (the boundary cell is padded with 0) and **passes** with the fix.
- The existing `test_boundary_constant` did not catch this because it used `fill_value=0` on the decorator, which coincides with the ignored default.
- Full `test_grid_ufunc.py` suite: 61 passed, 1 skipped, 7 xfailed.