### PR TITLE
Fix hash-seed-dependent / incorrect halos in face_connections padding

### DIFF
--- a/xgcm/padding.py
+++ b/xgcm/padding.py
@@ -264,14 +264,21 @@ def _pad_face_connections(
                             [co for co in source_slice.coords]
                         )
 
-                        # Here I am trying to emulate the way xarray.pad deals with dimension coordinates
-                        # I will set them to nan in any case. This might change later.
-                        if target_dim in target_slice.coords:
-                            if (
-                                target_dim not in source_slice.dims
-                            ):  # in case this a 1 element padding slice
-                                source_slice = source_slice.expand_dims([target_dim])
+                        # The squeeze above drops the length-1 `target_dim` from the
+                        # source slice. Restore it unconditionally so the concat below
+                        # always sees matching dimensions. Previously this only happened
+                        # when `target_dim` carried a coordinate variable; on a grid
+                        # whose padded dims have no coordinates the slice stayed 1-D and
+                        # `xr.concat(..., join="override")` silently transposed and
+                        # clobbered the orthogonal connected edge -- and, because the
+                        # axes are iterated in `set` (hash-seed) order, which edge ended
+                        # up wrong varied from run to run.
+                        if target_dim not in source_slice.dims:  # 1-element padding slice
+                            source_slice = source_slice.expand_dims([target_dim])
 
+                        # Emulate the way xarray.pad deals with dimension coordinates:
+                        # blank them out (only relevant when the dim has a coordinate).
+                        if target_dim in target_slice.coords:
                             source_slice = source_slice.assign_coords(
                                 {
                                     target_dim: np.full_like(
@@ -281,6 +288,13 @@ def _pad_face_connections(
                                     )
                                 }
                             )
+
+                        # Match the source slice's dimension order to the target's.
+                        # `expand_dims` prepends the restored `target_dim`, so without
+                        # this the two operands can disagree on axis order and
+                        # `xr.concat(..., join="override")` produces a transposed/
+                        # clobbered result (order-dependent, hence hash-seed dependent).
+                        source_slice = source_slice.transpose(*target_slice.dims)
 
                         # assemble the padded array
                         if is_right:

--- a/xgcm/padding.py
+++ b/xgcm/padding.py
@@ -273,7 +273,9 @@ def _pad_face_connections(
                         # clobbered the orthogonal connected edge -- and, because the
                         # axes are iterated in `set` (hash-seed) order, which edge ended
                         # up wrong varied from run to run.
-                        if target_dim not in source_slice.dims:  # 1-element padding slice
+                        if (
+                            target_dim not in source_slice.dims
+                        ):  # 1-element padding slice
                             source_slice = source_slice.expand_dims([target_dim])
 
                         # Emulate the way xarray.pad deals with dimension coordinates:

--- a/xgcm/test/test_faceconnections.py
+++ b/xgcm/test/test_faceconnections.py
@@ -422,6 +422,42 @@ def test_diff_interp_cubed_sphere(cs, cubed_sphere_connections):
     np.testing.assert_allclose(face_diff_y[:, 0, -1], [-4, -3, -2, -1, 2, 5])
 
 
+def test_cubed_sphere_scalar_pad_connected_halos(cs, cubed_sphere_connections):
+    # Regression test for GH #712. Padding a field whose connected dims carry no
+    # coordinate variables used to leave the source slice 1-D (the dim-restoring
+    # ``expand_dims`` was gated on the dim having a coordinate), so
+    # ``xr.concat(..., join="override")`` transposed and clobbered the orthogonal
+    # connected edge. Because the axes were iterated in ``set`` (hash-seed) order,
+    # which edge came out wrong varied from one Python process to the next.
+    #
+    # Here we pad a coordinate-less field equal to the face index, so every
+    # connected halo cell must read the neighbor face that the connections declare.
+    from xgcm.padding import pad as _pad
+
+    grid = Grid(cs, face_connections=cubed_sphere_connections)
+    nf, ny, nx = cs.sizes["face"], cs.sizes["y"], cs.sizes["x"]
+    face_field = xr.DataArray(
+        np.broadcast_to(np.arange(nf)[:, None, None], (nf, ny, nx)).astype(float),
+        dims=("face", "y", "x"),
+    )
+    padded = _pad(
+        face_field,
+        grid,
+        {"X": (1, 1), "Y": (1, 1)},
+        boundary={"X": "fill", "Y": "fill"},
+        fill_value=np.nan,
+    ).values  # (face, y+2, x+2)
+
+    for f in range(nf):
+        conn = cubed_sphere_connections["face"][f]
+        (left_x, right_x), (down_y, up_y) = conn["X"], conn["Y"]
+        # interior of each edge (exclude the two corner cells) reads the source face
+        np.testing.assert_array_equal(padded[f, 1:-1, 0], left_x[0])
+        np.testing.assert_array_equal(padded[f, 1:-1, -1], right_x[0])
+        np.testing.assert_array_equal(padded[f, 0, 1:-1], down_y[0])
+        np.testing.assert_array_equal(padded[f, -1, 1:-1], up_y[0])
+
+
 class TestErrors:
     def test_vector_missing_other_component(self, ds, ds_face_connections_x_to_y):
         grid = Grid(ds, face_connections=ds_face_connections_x_to_y)


### PR DESCRIPTION
Fixes #712.

## Problem

For a grid with `face_connections`, `xgcm.padding.pad` could fill connected halo cells with the **wrong** neighbor face, and **which** result you got depended on `PYTHONHASHSEED` — i.e. the same grid gave correct connectivity in one Python process and incorrect connectivity in the next.

Minimal demonstration on `master` (cubed-sphere connectivity; pad a field equal to the face index and read face 0's right-edge halo, which connects to face 1):

```
PYTHONHASHSEED=0  face0 right-edge halo = [5, 5, 5, 5, 5]   # WRONG (face 5 is the UP neighbor)
PYTHONHASHSEED=2  face0 right-edge halo = [1, 1, 1, 1, 1]   # OK
PYTHONHASHSEED=6  face0 right-edge halo = [5, 5, 5, 5, 5]   # WRONG
```

## Root cause

In `_pad_face_connections`, each source slice is `squeeze()`-d (dropping the length-1 `target_dim`), but the dim was only restored via `expand_dims` **when `target_dim` carried a coordinate variable**:

```python
if target_dim in target_slice.coords:
    if target_dim not in source_slice.dims:
        source_slice = source_slice.expand_dims([target_dim])
    ...
```

On a grid whose padded dims have **no coordinates**, that branch is skipped, so the source slice stays 1-D. `xr.concat(..., join="override")` then silently transposes and broadcasts it, clobbering the orthogonal axis's already-filled connected edge. Because `pad_axes` is built from a `set` (hash-seed-dependent iteration order), whichever axis is padded *last* wins and the other axis's connected edges come out wrong — so the corruption is non-deterministic across processes.

This is why it went unnoticed: the existing cubed-sphere tests pad `data_c`, which *has* coordinates, so they always took the working branch.

## Fix

1. Restore the squeezed `target_dim` **unconditionally** (keep only the coordinate *blanking* gated on the dim having a coordinate).
2. `transpose` the source slice to the target's dimension order before concatenating, so the result no longer depends on axis iteration order.

## Tests

Added `test_cubed_sphere_scalar_pad_connected_halos`: pads a coordinate-less face-index field on the cubed-sphere fixture and asserts every connected halo reads the declared neighbor face. It fails on `master` for several hash seeds and passes deterministically with this fix.

- `test_padding.py` + `test_faceconnections.py`: **147 passed, 28 xfailed** (unchanged).
- Full suite green except pre-existing `test_transform.py … [*-distributed_client]` failures, which are `dask.distributed` import errors unrelated to this change (they fail identically on pristine `master`).
- With the fix, the cubed-sphere halos are correct **and** byte-identical across `PYTHONHASHSEED` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
