### PR TITLE
ci: modernize the Python test matrix (fix the free-threaded 3.14 trap)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,10 +56,13 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         pixi-env:
-          - test-latest
           - test-minimum
+          - test-py310
           - test-py311
+          - test-py312
+          - test-py313
           - test-core
+          - test-latest
           - test-nightly
     env:
       PIXI_ENV: ${{ matrix.pixi-env }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,11 +144,25 @@ xarray = "0.20.*"
 
 # TODO: Update with rest of core deps
 
+[tool.pixi.feature.py310.dependencies]
+python = "3.10.*"
+
 [tool.pixi.feature.py311.dependencies]
 python = "3.11.*"
 
+[tool.pixi.feature.py312.dependencies]
+python = "3.12.*"
+
 [tool.pixi.feature.py313.dependencies]
 python = "3.13.*"
+
+[tool.pixi.feature.py314.dependencies]
+# Pin the standard (GIL) CPython build for the 3.14 test env. The free-threaded
+# `cp314t` variant has a sparse conda-forge ecosystem and an unconstrained solve
+# selects it, breaking dependency resolution (e.g. it collapses the pre-commit
+# toolchain down to an ancient `identify`). This is also why the default dev env
+# pins `py313` rather than floating to the latest Python.
+python = { version = "3.14.*", build = "*cp314" }
 
 [tool.pixi.feature.test.dependencies]
 pytest = "*"
@@ -203,16 +217,22 @@ default = { features = [
   "test",
   "extra",
   "pre-commit",
+  "py313",
 ], solve-group = "main" }
 
-test-core = { features = ["test"] }
-test-latest = { features = ["test", 'extra'] }
+# Core deps only (no `extra`) and full deps, both on the latest standard Python.
+test-core = { features = ["test", "py314"] }
+test-latest = { features = ["test", "extra", "py314"] }
 test-nightly = { features = [
   "py313",
   "nightly",
   "test",
 ], no-default-feature = true }
 
+# One explicit env per supported minor, all on standard (GIL) builds.
 test-minimum = { features = ["test", "minimum"] }
+test-py310 = { features = ["test", "py310"] }
 test-py311 = { features = ["test", "py311"] }
-docs = { features = ["docs", "extra", "notebooks"], solve-group = "docs" }
+test-py312 = { features = ["test", "py312"] }
+test-py313 = { features = ["test", "py313"] }
+docs = { features = ["docs", "extra", "notebooks", "py313"], solve-group = "docs" }


### PR DESCRIPTION
## Problem

`pixi run lint` fails with `InvalidConfigError: ... Type tag 'jupyter' is not recognized`.

**Root cause:** the default pixi dev environment has no Python pin, so it floats to Python 3.14's **free-threaded (`cp314t`, no-GIL) build**. That variant's conda-forge ecosystem is still sparse, so an unconstrained solve can't assemble a modern toolchain and collapses `identify` down to an ancient **1.2.2** that predates the `jupyter` type tag used by `.pre-commit-config.yaml` — so `pre-commit` aborts at config load. This is the *free-threaded* variant specifically — **not** a fundamental Python 3.14 incompatibility, and **not** a stale lock (a fresh solve still selects `cp314t`).

Auditing the matrix surfaced more: `test-core`, `test-latest` and `docs` also **float** to "whatever's newest" (the same `cp314t`), and the matrix had **holes** — no 3.10, no 3.12, no *stable* 3.13, and no *standard* 3.14.

## Fix — make the whole matrix explicit, on standard (GIL) builds

- Add `py310`, `py312`, `py314` features and one env per supported minor → CI now tests **3.9, 3.10, 3.11, 3.12, 3.13, 3.14** explicitly.
- `py314` pins the **standard build** (`build = "*cp314"`); `test-core` (core deps) and `test-latest` (with `extra`) now target standard 3.14 instead of floating onto the free-threaded build.
- Pin the default dev env and `docs` to `py313` so nothing floats.
- Update the `.github/workflows/ci.yaml` matrix to the full env list.

A real new user on Python 3.14 gets the standard `cp314` build, so the pinned envs match what users actually run — the old floating envs were testing the unrepresentative free-threaded variant.

`pixi.lock` is gitignored, so the committed change is sufficient for CI and fresh clones. (Developers with an existing 3.14 lock should delete `pixi.lock` and re-solve.)

## Verified locally
- Every env resolves its intended **standard-build** Python: 3.9.23, 3.10.20, 3.11.15, 3.12.13, 3.13.14 (`cp313`), 3.14.6 (`cp314`); `docs` → 3.13.14.
- `pixi run lint` loads and runs (identify 2.6.19).
- Test suite passes: **4120** on 3.12, and **4212** on 3.13 and 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
