### PR TITLE
Fix ReadTheDocs build: pin pixi to a known-good version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,14 @@ name = "xgcm"
 version = "dynamic" # dynamic versioning needs better support in pixi https://github.com/prefix-dev/pixi/issues/2923#issuecomment-2598460666 . Putting `version = "dynamic"` here for now until pixi recommends something else.
 
 [tool.pixi.package.build]
+# This build backend talks to the pixi tool over a private `pixi-build-api-version`
+# contract (pixi-build is still a preview feature). The `0.4.*` backend only
+# supports the api-version provided by pixi up to ~0.70.x; pixi 0.71.x bumped it
+# and the solve fails with "no candidates" for pixi-build-api-version. So the pixi
+# *tool* version must stay compatible with this *backend* pin. Keep them in sync:
+#   - CI pins the tool via `PIXI_VERSION` in .github/workflows/ci.yaml
+#   - ReadTheDocs pins it via `asdf install pixi <ver>` in readthedocs.yml
+# If you bump this backend (0.5.x+), drop those tool pins / allow newer pixi.
 backend = { name = "pixi-build-python", version = "0.4.*" }
 
 [tool.pixi.package.host-dependencies]

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,9 +10,15 @@ build:
     python: "latest"
   jobs:
     create_environment:
+      # Pin pixi to a known-good version instead of `latest`. pixi 0.71.x ships
+      # a `pixi-build-api-version` that the pinned `pixi-build-python = "0.4.*"`
+      # build backend (in pyproject.toml) can no longer resolve against, so
+      # `pixi install -e docs` fails to solve the environment. 0.70.2 is the
+      # last version that produced a successful build. See the solver error:
+      # https://app.readthedocs.org/projects/xgcm/builds/33330391/
       - asdf plugin add pixi
-      - asdf install pixi latest
-      - asdf global pixi latest
+      - asdf install pixi 0.70.2
+      - asdf global pixi 0.70.2
     install:
       - pixi install -e docs
     build:


### PR DESCRIPTION
## Root cause
The RTD docs build died in ~14 s during `pixi install -e docs` — before any docs were built — with a solver error ([build 33330391](https://app.readthedocs.org/projects/xgcm/builds/33330391/)):

```
× failed to solve requirements of environment 'default'
╰─▶ pixi-build-python 0.4.* cannot be installed because there are no viable options:
    ├─ 0.4.4 … 0.4.8 would require pixi-build-api-version >=4,<5 (no candidates)
    └─ 0.4.0 … 0.4.3 would require pixi-build-api-version >=2,<3 (no candidates)
```

`pixi-build-python` is the **build backend** pixi uses to build xgcm itself (the project lists `xgcm = { path = "." }` under the `pixi-build` preview, so every env — including `docs` — must build it). The backend talks to the pixi **tool** over a private `pixi-build-api-version` contract. `readthedocs.yml` installs **`latest`** pixi; the failing build pulled pixi **0.71.x**, which advanced that api-version past what the pinned `pixi-build-python = "0.4.*"` backend supports → no candidates → the env never solves.

It's a **moving-target regression, not a code change**: the last green build (2026-06-24) used pixi **0.70.2**. CI was unaffected because it already pins the tool (`PIXI_VERSION` in `ci.yaml`); RTD was the only place floating `latest`.

## Fix
- **`readthedocs.yml`** — pin `asdf install/global pixi 0.70.2` instead of `latest` (a tool version compatible with the `0.4.*` backend; the last known-good pair).
- **`pyproject.toml`** — add a comment at `[tool.pixi.package.build]` documenting the tool↔backend api-version coupling, so the next person knows the consuming pixi pins (CI + RTD) must track this backend.

No CI change needed — `ci.yaml` already pins `PIXI_VERSION: "v0.63.0"`.

## Verified
Reproduced the green path locally: `pixi run -e docs mkdocs build --strict` → "Documentation built in ~24 s", `--strict` passes. The only un-confirmable bit is the actual RTD rebuild, which runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)