### PR TITLE
Fix #575: preserve non-core input coordinates (e.g. time) across grid ufuncs

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -46,6 +46,12 @@
 
 ### Bugfixes
 
+- Fix grid operations (`interp`, `diff`, etc.) silently dropping non-core coordinates that ride on the
+  input data but are not stored on the grid's dataset (e.g. a `time` coordinate). Padding strips all
+  coordinates and they were only restored from `grid._ds`; such coordinates are now also restored from
+  the input arguments. ([#575](https://github.com/xgcm/xgcm/issues/575)).
+  By [Henri Drake](https://github.com/hdrake).
+
 - Fix bug in `xgcm.transform.transform` that violated tracer conservation when using conservative interpolation in the presence of nans. ([#635](https://github.com/xgcm/xgcm/pull/635))
   By [Julius Busecke](https://github.com/jbusecke).
 - Fix bug in `xgcm.padding._maybe_rename_grid_positions` where dimensions were assumed to have coordinate

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -806,9 +806,21 @@ def apply_as_grid_ufunc(
 
     # TODO add option to trim result if not done in ufunc
 
+    # Collect non-core coordinates carried on the input arguments. Padding strips all
+    # coordinates, and they are normally restored from grid._ds; but coordinates that
+    # live on the data and not on grid._ds (e.g. a `time` coordinate on the array being
+    # operated on) would otherwise be lost. See GH #575.
+    input_coords: Dict[str, xr.DataArray] = {}
+    for arg in args:
+        arg_da = _maybe_unpack_vector_component(arg)
+        for name, coord in arg_da.coords.items():
+            input_coords.setdefault(name, coord)
+
     # Restore any dimension coordinates associated with new output dims that are present in grid
     # Also throws loud warning if ufunc returns array of incorrect size
-    results_with_coords = _reattach_coords(results, grid, boundary_width, keep_coords)
+    results_with_coords = _reattach_coords(
+        results, grid, boundary_width, keep_coords, input_coords
+    )
 
     # Return single results not wrapped in 1-element tuple, like xr.apply_ufunc does
     if len(results_with_coords) == 1:
@@ -1110,7 +1122,11 @@ def _identify_dummy_axes_with_real_axes(
 
 
 def _reattach_coords(
-    results: Sequence[xr.DataArray], grid: "Grid", boundary_width, keep_coords: bool
+    results: Sequence[xr.DataArray],
+    grid: "Grid",
+    boundary_width,
+    keep_coords: bool,
+    input_coords: Optional[Dict[str, xr.DataArray]] = None,
 ) -> List[xr.DataArray]:
     results_with_coords = []
     for res in results:
@@ -1121,6 +1137,16 @@ def _reattach_coords(
             for coord, da_coord in grid._ds.coords.items()
             if all(dim in res.dims for dim in da_coord.dims)
         }
+
+        # Also restore coordinates that were carried on the input arguments but are not
+        # present on grid._ds (e.g. a `time` coordinate on the data), as long as all of
+        # their dimensions survive in the output. grid._ds takes precedence on conflict,
+        # so transformed core-dimension coordinates are not clobbered. See GH #575.
+        for coord, da_coord in (input_coords or {}).items():
+            if coord in all_matching_coords:
+                continue
+            if all(dim in res.dims for dim in da_coord.dims):
+                all_matching_coords[coord] = da_coord
 
         try:
             res = res.assign_coords(all_matching_coords)

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -689,6 +689,47 @@ class TestGridUfuncWithPadding:
         ).compute()
         assert_equal(result, expected)
 
+    @pytest.mark.parametrize("chunk", [False, True])
+    def test_non_core_coord_on_input_is_preserved(self, chunk):
+        """Coordinates carried on the input data but absent from grid._ds (e.g. a
+        ``time`` coordinate) must survive the pad/unpad round-trip. See GH #575."""
+
+        def diff_center_to_left(a):
+            return a[..., 1:] - a[..., :-1]
+
+        grid = create_1d_test_grid("depth")
+
+        time = xr.DataArray(
+            np.array([10, 20, 30], dtype="float32"), dims="time", name="time"
+        )
+        label = xr.DataArray(["a", "b", "c"], dims="time")
+        da = xr.DataArray(
+            np.random.rand(3, 9),
+            dims=["time", "depth_c"],
+            coords={"time": time, "label": label, "depth_c": grid._ds.depth_c},
+        )
+        if chunk:
+            da = da.chunk({"time": 1})
+
+        result = apply_as_grid_ufunc(
+            diff_center_to_left,
+            da,
+            axis=[("depth",)],
+            grid=grid,
+            signature="(X:center)->(X:left)",
+            boundary_width={"X": (1, 0)},
+            dask="parallelized" if chunk else "forbidden",
+        )
+
+        # The dimension coordinate `time` and the non-dimension coordinate `label`
+        # both ride on a dimension that survives the operation, so both must remain,
+        # with their original values and dtype intact.
+        assert "time" in result.coords
+        assert "label" in result.coords
+        assert result["time"].dtype == time.dtype
+        np.testing.assert_array_equal(result["time"].values, time.values)
+        np.testing.assert_array_equal(result["label"].values, label.values)
+
     def test_2d_padding(self):
         def diff(a, axis):
             def _diff(a):


### PR DESCRIPTION
## What

Grid operations (`interp`, `diff`, etc.) silently dropped non-core coordinates that ride on the **input data** but are not stored on the grid's dataset — the classic case being a `time` coordinate on the array being operated on. Fixes #575.

## Why

Padding strips **all** coordinates before applying a grid ufunc (`xgcm/padding.py`, `_strip_all_coords`). They were then restored in `apply_as_grid_ufunc` by `_reattach_coords`, which only looked them up on `grid._ds.coords`. Any coordinate present on the input `DataArray` but absent from the grid's stored dataset was therefore never reattached and was lost.

## How

- `apply_as_grid_ufunc` now collects non-core coordinates from the input arguments (unpacking vector components) and passes them to `_reattach_coords`.
- `_reattach_coords` restores those input coordinates as long as **all** of their dimensions survive in the output. `grid._ds` still takes precedence on name conflicts, so transformed core-dimension coordinates are never clobbered.

## Tests

- Added `test_non_core_coord_on_input_is_preserved` in `xgcm/test/test_grid_ufunc.py`, parametrized over numpy and dask backends. It verifies a `time` dimension coordinate and a non-dimension coordinate (`label`) both survive a `diff` with padding, with original values and dtype intact.
- Confirmed the test fails on `master` and passes with this change.
- Full suite green (`pixi run tests`): 4181 passed.

## Changelog

Added a Bugfixes entry under v0.9.0 in `docs/whats-new.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)