### PR TITLE
Fix #496 and #575: preserve non-core input coordinates through grid operations

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -46,12 +46,12 @@
 
 ### Bugfixes
 
-- Grid operations (e.g. `Grid.interp`, `Grid.diff`) no longer drop or clobber non-core coordinates carried
-  on the input `DataArray`. Padding strips all coordinates and they were only restored from the grid's own
-  dataset, so a coordinate that lived on the input but not on the grid (e.g. a `time` coordinate) was lost,
-  and a coordinate present on both was overwritten with the grid's (possibly stale) copy. Coordinates on
-  non-core dimensions are now preserved from the input array (first input wins for repeated names), while
-  the newly position-shifted core-dim coordinate still comes from the grid
+- Grid operations (e.g. `Grid.interp`, `Grid.diff`, `Grid.cumsum`) no longer drop or clobber non-core
+  coordinates carried on the input `DataArray`. Padding strips all coordinates and they were only restored
+  from the grid's own dataset, so a coordinate that lived on the input but not on the grid (e.g. a `time`
+  coordinate) was lost, and a coordinate present on both was overwritten with the grid's (possibly stale)
+  copy. Coordinates on non-core dimensions are now preserved from the input array (first input wins for
+  repeated names), while the newly position-shifted core-dim coordinate still comes from the grid
   ([#496](https://github.com/xgcm/xgcm/issues/496), [#575](https://github.com/xgcm/xgcm/issues/575)).
 
 - Fix `TypeError: dict.copy() takes no keyword arguments` when applying vector grid ufuncs (e.g.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -53,7 +53,7 @@
   non-core dimensions are now preserved from the input array (first input wins for repeated names), while
   the newly position-shifted core-dim coordinate still comes from the grid
   ([#496](https://github.com/xgcm/xgcm/issues/496), [#575](https://github.com/xgcm/xgcm/issues/575)).
-  
+
 - Fix `TypeError: dict.copy() takes no keyword arguments` when applying vector grid ufuncs (e.g.
   `diff_2d_vector`, `interp_2d_vector`) on grids *without* face connections. A vector component supplied
   as a `{axis_name: DataArray}` dict was forwarded unchanged by `xgcm.padding.pad` to the basic padding

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -46,6 +46,12 @@
 
 ### Bugfixes
 
+- Grid operations (e.g. `Grid.interp`, `Grid.diff`) no longer clobber coordinates the user set on the
+  input `DataArray` for non-core dimensions with the (possibly stale) copy stored in the grid. Coordinates
+  on non-core dimensions are now preserved from the input array, while the newly position-shifted core-dim
+  coordinate still comes from the grid ([#496](https://github.com/xgcm/xgcm/issues/496)).
+  By [Henri Drake](https://github.com/hdrake).
+
 - Fix `diff_2d_vector`/`interp_2d_vector` (and the equivalent vector-component `Grid.diff`/`Grid.interp`)
   on grids with face connections when a vector component is a dask array chunked into more than one chunk
   along its core dimension. The `map_overlap` path now derives the output chunk spec from the padded,

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -46,10 +46,13 @@
 
 ### Bugfixes
 
-- Grid operations (e.g. `Grid.interp`, `Grid.diff`) no longer clobber coordinates the user set on the
-  input `DataArray` for non-core dimensions with the (possibly stale) copy stored in the grid. Coordinates
-  on non-core dimensions are now preserved from the input array, while the newly position-shifted core-dim
-  coordinate still comes from the grid ([#496](https://github.com/xgcm/xgcm/issues/496)).
+- Grid operations (e.g. `Grid.interp`, `Grid.diff`) no longer drop or clobber non-core coordinates carried
+  on the input `DataArray`. Padding strips all coordinates and they were only restored from the grid's own
+  dataset, so a coordinate that lived on the input but not on the grid (e.g. a `time` coordinate) was lost,
+  and a coordinate present on both was overwritten with the grid's (possibly stale) copy. Coordinates on
+  non-core dimensions are now preserved from the input array (first input wins for repeated names), while
+  the newly position-shifted core-dim coordinate still comes from the grid
+  ([#496](https://github.com/xgcm/xgcm/issues/496), [#575](https://github.com/xgcm/xgcm/issues/575)).
   By [Henri Drake](https://github.com/hdrake).
 
 - Fix `diff_2d_vector`/`interp_2d_vector` (and the equivalent vector-component `Grid.diff`/`Grid.interp`)

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -1126,6 +1126,11 @@ class Grid:
         for ax in axes:
             pos, dim = ax._get_position_name(da)
 
+            # Capture the input array (with its coordinates) before it is mutated
+            # below; its NON-core coordinates should survive the operation rather
+            # than being clobbered by the grid's (possibly stale) copies. See #496.
+            input_da = data
+
             ax_metric_weighted = metric_weighted[ax.name]
             if ax_metric_weighted:
                 metric = self.get_metric(data, ax_metric_weighted)
@@ -1185,6 +1190,11 @@ class Grid:
                 grid=self,
                 boundary_width=ax_boundary_width,
                 keep_coords=keep_coords,
+                # The only newly position-shifted (core) dim is the result dim;
+                # its coordinate must come from the grid. Coordinates on all other
+                # (non-core) dims should be preserved from the input array. #496.
+                out_core_dim_names={new_dim_name},
+                input_args=[input_da],
             )[0]
 
             ax_metric_weighted = metric_weighted[ax.name]

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -1161,7 +1161,9 @@ def _reattach_coords(
             # those must come from grid._ds instead.
             if any(dim in out_core_dim_names for dim in da_coord.dims):
                 continue
-            input_coords[coord] = da_coord
+            # If multiple input args carry a coord of the same name, the first
+            # arg wins (matches the precedence convention used in #719).
+            input_coords.setdefault(coord, da_coord)
 
     results_with_coords = []
     for res in results:

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -11,6 +11,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Union,
     get_type_hints,
@@ -808,7 +809,14 @@ def apply_as_grid_ufunc(
 
     # Restore any dimension coordinates associated with new output dims that are present in grid
     # Also throws loud warning if ufunc returns array of incorrect size
-    results_with_coords = _reattach_coords(results, grid, boundary_width, keep_coords)
+    # Flatten the output core dims to a set of dim names; coords on these (newly
+    # position-shifted) dims must come from grid._ds, but coords on all other
+    # (non-core) dims should preserve whatever the user set on the input args.
+    out_core_dim_names = set(d for arg in out_core_dims for d in arg)
+    input_args = [_maybe_unpack_vector_component(arg) for arg in args]
+    results_with_coords = _reattach_coords(
+        results, grid, boundary_width, keep_coords, out_core_dim_names, input_args
+    )
 
     # Return single results not wrapped in 1-element tuple, like xr.apply_ufunc does
     if len(results_with_coords) == 1:
@@ -1129,8 +1137,32 @@ def _identify_dummy_axes_with_real_axes(
 
 
 def _reattach_coords(
-    results: Sequence[xr.DataArray], grid: "Grid", boundary_width, keep_coords: bool
+    results: Sequence[xr.DataArray],
+    grid: "Grid",
+    boundary_width,
+    keep_coords: bool,
+    out_core_dim_names: Optional[Set[str]] = None,
+    input_args: Optional[Sequence[xr.DataArray]] = None,
 ) -> List[xr.DataArray]:
+    if out_core_dim_names is None:
+        out_core_dim_names = set()
+    if input_args is None:
+        input_args = []
+
+    # Collect coordinates carried on the original input arguments. These should
+    # take precedence over grid._ds for any coordinate that lives entirely on
+    # NON-core (i.e. not position-shifted) dimensions, so that coordinate values
+    # the user modified on the input array (e.g. a recast `time` coordinate on a
+    # dim untouched by the operation) survive the round-trip. See GH #496.
+    input_coords: Dict[str, xr.DataArray] = {}
+    for arg in input_args:
+        for coord, da_coord in arg.coords.items():
+            # Skip coords that touch a core (newly created/shifted) output dim;
+            # those must come from grid._ds instead.
+            if any(dim in out_core_dim_names for dim in da_coord.dims):
+                continue
+            input_coords[coord] = da_coord
+
     results_with_coords = []
     for res in results:
         # padding strips all coordinates (including dimension coordinates).
@@ -1140,6 +1172,12 @@ def _reattach_coords(
             for coord, da_coord in grid._ds.coords.items()
             if all(dim in res.dims for dim in da_coord.dims)
         }
+
+        # Let coords from the input args override those from grid._ds when they
+        # live entirely on non-core dims that are present in the result.
+        for coord, da_coord in input_coords.items():
+            if all(dim in res.dims for dim in da_coord.dims):
+                all_matching_coords[coord] = da_coord
 
         try:
             res = res.assign_coords(all_matching_coords)

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -452,6 +452,59 @@ def test_preserve_input_noncore_coords(funcname, use_dask):
     assert "xc_aux" not in out.coords
 
 
+@pytest.mark.parametrize("use_dask", [False, True])
+def test_cumsum_preserves_input_noncore_coords(use_dask):
+    # Regression test for GH #496/#575 extended to `Grid.cumsum`: a coordinate
+    # carried on the INPUT array for a non-core dimension (here `time`, and the
+    # non-dimension `t_label`) must be preserved through the cumsum, rather than
+    # dropped or clobbered with the (stale) grid copy. The newly position-shifted
+    # core-dim coordinate must still come from the grid.
+    N = 8
+    time = np.arange(N) * np.timedelta64(600, "s")
+    ds = xr.Dataset(coords={"XC": np.arange(N) + 0.5, "XG": np.arange(N), "time": time})
+    ds = ds.assign_coords(
+        t_label=("time", np.arange(N).astype("int64")),
+        xc_aux=("XC", np.arange(N).astype("int64") * 10),
+    )
+    ds["v"] = xr.DataArray(np.random.rand(N, N), dims=["time", "XC"])
+    grid = Grid(
+        ds,
+        coords={"X": {"center": "XC", "left": "XG"}},
+        periodic=True,
+        autoparse_metadata=False,
+    )
+
+    # User recasts the non-core coords on the input array.
+    new_time = (np.arange(N) * 600 / 3600.0).astype(np.float32)
+    new_t_label = (np.arange(N) + 100).astype(np.float32)
+    new_xc_aux = (np.arange(N) + 500).astype(np.float32)
+    v = ds.v.assign_coords(
+        time=new_time, t_label=("time", new_t_label), xc_aux=("XC", new_xc_aux)
+    )
+    if use_dask:
+        v = v.chunk({"time": 4})
+
+    out = grid.cumsum(v, "X", to="left", keep_coords=True)
+
+    # The user's modified non-core dimension coord must survive (dtype AND values).
+    assert out.time.dtype == np.float32
+    np.testing.assert_array_equal(out.time.values, new_time)
+
+    # The user's modified non-core, non-dimension coord must survive too.
+    assert "t_label" in out.coords
+    assert out["t_label"].dtype == np.float32
+    np.testing.assert_array_equal(out["t_label"].values, new_t_label)
+
+    # The shifted core-dim coordinate must still be attached from the grid.
+    assert "XG" in out.coords
+    np.testing.assert_array_equal(out["XG"].values, ds["XG"].values)
+
+    # XC is no longer a dimension of the result, so `xc_aux` (on XC) must be
+    # absent rather than incorrectly re-attached from the input.
+    assert "XC" not in out.dims
+    assert "xc_aux" not in out.coords
+
+
 def test_boundary_kwarg_same_as_grid_constructor_kwarg():
     ds = datasets["2d_left"]
     ds, grid_kwargs = parse_comodo(ds)

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -368,9 +368,7 @@ def test_preserve_input_noncore_coords(funcname, use_dask):
     # core-dim coordinate must still come from the grid.
     N = 8
     time = np.arange(N) * np.timedelta64(600, "s")
-    ds = xr.Dataset(
-        coords={"XC": np.arange(N) + 0.5, "XG": np.arange(N), "time": time}
-    )
+    ds = xr.Dataset(coords={"XC": np.arange(N) + 0.5, "XG": np.arange(N), "time": time})
     ds["v"] = xr.DataArray(np.random.rand(N, N), dims=["time", "XC"])
     grid = Grid(
         ds,

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -369,6 +369,12 @@ def test_preserve_input_noncore_coords(funcname, use_dask):
     N = 8
     time = np.arange(N) * np.timedelta64(600, "s")
     ds = xr.Dataset(coords={"XC": np.arange(N) + 0.5, "XG": np.arange(N), "time": time})
+    # `t_label` is a NON-dimension coordinate on the (non-core) `time` dim;
+    # `xc_aux` is an auxiliary coordinate on the (core) center dim XC.
+    ds = ds.assign_coords(
+        t_label=("time", np.arange(N).astype("int64")),
+        xc_aux=("XC", np.arange(N).astype("int64") * 10),
+    )
     ds["v"] = xr.DataArray(np.random.rand(N, N), dims=["time", "XC"])
     grid = Grid(
         ds,
@@ -377,21 +383,40 @@ def test_preserve_input_noncore_coords(funcname, use_dask):
         autoparse_metadata=False,
     )
 
-    # User recasts the non-core `time` coordinate on the input array.
+    # User recasts the non-core coords on the input array: the `time` dimension
+    # coordinate and the non-dimension `t_label` coordinate. Also recast the
+    # core-dim auxiliary coord `xc_aux`.
     new_time = (np.arange(N) * 600 / 3600.0).astype(np.float32)
-    v = ds.v.assign_coords({"time": new_time})
+    new_t_label = (np.arange(N) + 100).astype(np.float32)
+    new_xc_aux = (np.arange(N) + 500).astype(np.float32)
+    v = ds.v.assign_coords(
+        time=new_time, t_label=("time", new_t_label), xc_aux=("XC", new_xc_aux)
+    )
     if use_dask:
         v = v.chunk({"time": 4})
 
-    out = getattr(grid, funcname)(v, "X")
+    # keep_coords=True so that non-dimension coordinates are retained on output
+    # (the default drops them, which is unrelated to the #496 clobbering bug).
+    out = getattr(grid, funcname)(v, "X", keep_coords=True)
 
-    # The user's modified non-core coord must survive (dtype AND values).
+    # The user's modified non-core dimension coord must survive (dtype AND values).
     assert out.time.dtype == np.float32
     np.testing.assert_array_equal(out.time.values, new_time)
+
+    # The user's modified non-core, non-dimension coord must survive too.
+    assert "t_label" in out.coords
+    assert out["t_label"].dtype == np.float32
+    np.testing.assert_array_equal(out["t_label"].values, new_t_label)
 
     # The shifted core-dim coordinate must still be attached from the grid.
     assert "XG" in out.coords
     np.testing.assert_array_equal(out["XG"].values, ds["XG"].values)
+
+    # A coordinate spanning the (shifted) core dim must not be carried over
+    # stale: XC is no longer a dimension of the result, so `xc_aux` (which lives
+    # on XC) must be absent rather than incorrectly re-attached from the input.
+    assert "XC" not in out.dims
+    assert "xc_aux" not in out.coords
 
 
 def test_boundary_kwarg_same_as_grid_constructor_kwarg():

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -359,6 +359,43 @@ def test_keep_coords_deprecation():
             grid.diff(ds.tracer, axis_name, keep_coords=False)
 
 
+@pytest.mark.parametrize("funcname", ["interp", "diff"])
+@pytest.mark.parametrize("use_dask", [False, True])
+def test_preserve_input_noncore_coords(funcname, use_dask):
+    # Regression test for GH #496: grid operations should not clobber a
+    # coordinate the user set on the INPUT array for a non-core dimension with
+    # the (stale) version stored in grid._ds. The newly position-shifted
+    # core-dim coordinate must still come from the grid.
+    N = 8
+    time = np.arange(N) * np.timedelta64(600, "s")
+    ds = xr.Dataset(
+        coords={"XC": np.arange(N) + 0.5, "XG": np.arange(N), "time": time}
+    )
+    ds["v"] = xr.DataArray(np.random.rand(N, N), dims=["time", "XC"])
+    grid = Grid(
+        ds,
+        coords={"X": {"center": "XC", "left": "XG"}},
+        periodic=True,
+        autoparse_metadata=False,
+    )
+
+    # User recasts the non-core `time` coordinate on the input array.
+    new_time = (np.arange(N) * 600 / 3600.0).astype(np.float32)
+    v = ds.v.assign_coords({"time": new_time})
+    if use_dask:
+        v = v.chunk({"time": 4})
+
+    out = getattr(grid, funcname)(v, "X")
+
+    # The user's modified non-core coord must survive (dtype AND values).
+    assert out.time.dtype == np.float32
+    np.testing.assert_array_equal(out.time.values, new_time)
+
+    # The shifted core-dim coordinate must still be attached from the grid.
+    assert "XG" in out.coords
+    np.testing.assert_array_equal(out["XG"].values, ds["XG"].values)
+
+
 def test_boundary_kwarg_same_as_grid_constructor_kwarg():
     ds = datasets["2d_left"]
     ds, grid_kwargs = parse_comodo(ds)

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -689,6 +689,47 @@ class TestGridUfuncWithPadding:
         ).compute()
         assert_equal(result, expected)
 
+    @pytest.mark.parametrize("chunk", [False, True])
+    def test_non_core_coord_on_input_is_preserved(self, chunk):
+        """Coordinates carried on the input data but absent from grid._ds (e.g. a
+        ``time`` coordinate) must survive the pad/unpad round-trip. See GH #575."""
+
+        def diff_center_to_left(a):
+            return a[..., 1:] - a[..., :-1]
+
+        grid = create_1d_test_grid("depth")
+
+        time = xr.DataArray(
+            np.array([10, 20, 30], dtype="float32"), dims="time", name="time"
+        )
+        label = xr.DataArray(["a", "b", "c"], dims="time")
+        da = xr.DataArray(
+            np.random.rand(3, 9),
+            dims=["time", "depth_c"],
+            coords={"time": time, "label": label, "depth_c": grid._ds.depth_c},
+        )
+        if chunk:
+            da = da.chunk({"time": 1})
+
+        result = apply_as_grid_ufunc(
+            diff_center_to_left,
+            da,
+            axis=[("depth",)],
+            grid=grid,
+            signature="(X:center)->(X:left)",
+            boundary_width={"X": (1, 0)},
+            dask="parallelized" if chunk else "forbidden",
+        )
+
+        # The dimension coordinate `time` and the non-dimension coordinate `label`
+        # both ride on a dimension that survives the operation, so both must remain,
+        # with their original values and dtype intact.
+        assert "time" in result.coords
+        assert "label" in result.coords
+        assert result["time"].dtype == time.dtype
+        np.testing.assert_array_equal(result["time"].values, time.values)
+        np.testing.assert_array_equal(result["label"].values, label.values)
+
     def test_2d_padding(self):
         def diff(a, axis):
             def _diff(a):

--- a/xgcm/test/test_grid_ufunc.py
+++ b/xgcm/test/test_grid_ufunc.py
@@ -730,6 +730,82 @@ class TestGridUfuncWithPadding:
         np.testing.assert_array_equal(result["time"].values, time.values)
         np.testing.assert_array_equal(result["label"].values, label.values)
 
+    def test_non_core_coord_first_input_wins(self):
+        """When multiple inputs carry a same-named non-core coordinate with
+        different values, the first input's values win (matching the
+        ``setdefault`` first-wins precedence in ``_reattach_coords``)."""
+
+        def diff_of_diff(a, b):
+            return (a - b)[..., 1:]
+
+        grid = create_1d_test_grid("depth")
+
+        time_a = xr.DataArray(
+            np.array([10, 20, 30], dtype="float32"), dims="time", name="time"
+        )
+        time_b = xr.DataArray(
+            np.array([99, 98, 97], dtype="float32"), dims="time", name="time"
+        )
+        a = xr.DataArray(
+            np.random.rand(3, 9),
+            dims=["time", "depth_c"],
+            coords={"time": time_a, "depth_c": grid._ds.depth_c},
+        )
+        b = xr.DataArray(
+            np.random.rand(3, 9),
+            dims=["time", "depth_c"],
+            coords={"time": time_b, "depth_c": grid._ds.depth_c},
+        )
+
+        result = apply_as_grid_ufunc(
+            diff_of_diff,
+            a,
+            b,
+            axis=[("depth",), ("depth",)],
+            grid=grid,
+            signature="(X:center),(X:center)->(X:left)",
+            boundary_width={"X": (1, 0)},
+            dask="forbidden",
+        )
+
+        # The first input's `time` coordinate values must win.
+        assert "time" in result.coords
+        np.testing.assert_array_equal(result["time"].values, time_a.values)
+
+    def test_non_core_coord_on_vector_component_input_is_preserved(self):
+        """A vector component supplied as a ``{axis: DataArray}`` dict goes
+        through ``_maybe_unpack_vector_component``; non-core coordinates on the
+        inner DataArray must still survive the unpack + reattach."""
+
+        def diff_center_to_left(a):
+            return a[..., 1:] - a[..., :-1]
+
+        grid = create_1d_test_grid("depth")
+
+        time = xr.DataArray(
+            np.array([10, 20, 30], dtype="float32"), dims="time", name="time"
+        )
+        da = xr.DataArray(
+            np.random.rand(3, 9),
+            dims=["time", "depth_c"],
+            coords={"time": time, "depth_c": grid._ds.depth_c},
+        )
+
+        result = apply_as_grid_ufunc(
+            diff_center_to_left,
+            {"depth": da},
+            axis=[("depth",)],
+            grid=grid,
+            signature="(X:center)->(X:left)",
+            boundary_width={"X": (1, 0)},
+            dask="forbidden",
+        )
+
+        # The non-core `time` coordinate on the unpacked component must survive.
+        assert "time" in result.coords
+        assert result["time"].dtype == time.dtype
+        np.testing.assert_array_equal(result["time"].values, time.values)
+
     def test_2d_padding(self):
         def diff(a, axis):
             def _diff(a):


### PR DESCRIPTION
## What

Grid operations (`interp`, `diff`, etc.) mishandled coordinates carried on the **input** `DataArray` that sit on non-core (not position-shifted) dimensions:

- **#496** — a coordinate present on both the input and the grid (e.g. a user-recast `time`) was **clobbered** by the grid's (possibly stale) copy.
- **#575** — a coordinate present on the input but **not** on the grid (e.g. a `time` coordinate added to the data) was **dropped** entirely.

## Why

Padding strips all coordinates before applying a grid ufunc, and `_reattach_coords` restored them **only** from `grid._ds.coords`. So input-only coords were never restored (#575), and input coords that also existed on the grid were overwritten with the grid's version (#496).

## How

`apply_as_grid_ufunc` now passes the input arguments' coordinates to `_reattach_coords`, which:
- restores coordinates on **non-core** dims from the **input array** (first input wins for repeated names), and
- still takes the newly position-shifted **core-dim** coordinate from `grid._ds`.

This single change resolves both issues.

## Tests

- `test_preserve_input_noncore_coords` (`test_grid.py`) — interp/diff × numpy/dask: a user-set non-core coord is preserved, a stale core-dim coord is not carried over (#496).
- `test_non_core_coord_on_input_is_preserved` (`test_grid_ufunc.py`) — numpy/dask: a `time` dim-coord and a non-dim coord present on the input but absent from the grid both survive (#575).
- Both confirmed fail-before / pass-after; targeted suites green.

## Note

Supersedes #719 (which fixed #575 alone). Closes #496 and #575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)