### PR TITLE
Fix Binder build: bump Python to 3.12 and add numba

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,11 +1,12 @@
 name: xgcm
 dependencies:
-  - python=3.6
+  - python=3.12
   - xarray
   - netcdf4
   - dask
   - numpy
   - matplotlib
+  - numba
   - pip
   - pip:
     - git+https://github.com/xgcm/xgcm.git


### PR DESCRIPTION
## Problem

The Binder build fails during the conda/pip step. `binder/environment.yml` pins `python=3.6`, but xgcm's `pyproject.toml` build-system requires `setuptools>=61`, which has no release compatible with Python 3.6 (the last is 59.6.0). Installing xgcm from git into the 3.6 kernel environment therefore fails:

```
ERROR: Could not find a version that satisfies the requirement setuptools>=61
ERROR: No matching distribution found for setuptools>=61
```

which aborts the Docker build.

## Fix

- Bump `python=3.6` → `python=3.12`.
- Add `numba` (required by `xgcm.transform` and used by the example notebooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)