### PR TITLE
Fix Binder badge path to the MITgcm example notebook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ To learn how to install and use xgcm for your dataset, visit the `xgcm documenta
    :target: https://github.com/python/black
    :alt: Code style
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/xgcm/xgcm/master?filepath=doc%2Fexample_mitgcm.ipynb
+   :target: https://mybinder.org/v2/gh/xgcm/xgcm/master?filepath=docs%2Fxgcm-examples%2F02_mitgcm.ipynb
 .. |PBinder| image:: https://binder.pangeo.io/badge_logo.svg
    :target: https://binder.pangeo.io/v2/gh/pangeo-data/pangeo-ocean-examples/master
 .. |conda-forge| image:: https://img.shields.io/conda/dn/conda-forge/xgcm?label=conda-forge


### PR DESCRIPTION
## Problem

After #723 fixed the Binder build, the instance launches successfully but lands on a "file not found" — the Binder badge points at `doc%2Fexample_mitgcm.ipynb` (`doc/example_mitgcm.ipynb`), a stale Sphinx-era path that no longer exists in the repo.

## Fix

Since the docs moved to mkdocs, the example notebooks live in the **`docs/xgcm-examples`** git submodule, and the MITgcm example is **`02_mitgcm.ipynb`** (see `mkdocs.yml`: `MITgcm: xgcm-examples/02_mitgcm.ipynb`). This updates the badge's `filepath` to:

```
docs/xgcm-examples/02_mitgcm.ipynb
```

### Why this works
- `repo2docker` (mybinder) initializes git submodules during the build, so `docs/xgcm-examples/02_mitgcm.ipynb` is present in the launched image.
- Verified the notebook exists at the pinned submodule commit (`e41814e`, 359 KB).

One-line change to `README.rst`. Follows up on #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)