### PR TITLE
Fix stale Sphinx-era doc links

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_reminder.md
+++ b/.github/ISSUE_TEMPLATE/release_reminder.md
@@ -6,6 +6,6 @@ title: "Time to issue a new release"
 ---
 This is a reminder to release a shiny new version of xgcm.
 
-You can find instructions [here](https://xgcm.readthedocs.io/en/latest/contributor_guide.html#how-to-release-a-new-version-of-xgcm-for-maintainers-only).
+You can find instructions [here](https://xgcm.readthedocs.io/en/latest/contributor_guide/#how-to-release-a-new-version-of-xgcm-for-maintainers-only).
 
 @rabernat, @jbusecke, @TomNicholas

--- a/docs/grid_metrics.ipynb
+++ b/docs/grid_metrics.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Grid Metrics\n",
-    "Most modern circulation models discretize the partial differential equations needed to simulate the earth system on a logically rectangular grid. This means the grid for a single time step can be represented as a 3-dimensional array of cells. Even for more complex grid geometries like [here](https://xgcm.readthedocs.io/en/latest/grid_topology.html), subdomains are usually organized in this manner. A noteable exception are models with unstructured grids [example](https://en.wikipedia.org/wiki/Unstructured_grid), which currently cannot be processed with the datamodel of xarray and xgcm.\n",
+    "Most modern circulation models discretize the partial differential equations needed to simulate the earth system on a logically rectangular grid. This means the grid for a single time step can be represented as a 3-dimensional array of cells. Even for more complex grid geometries like [here](https://xgcm.readthedocs.io/en/latest/grid_topology/), subdomains are usually organized in this manner. A noteable exception are models with unstructured grids [example](https://en.wikipedia.org/wiki/Unstructured_grid), which currently cannot be processed with the datamodel of xarray and xgcm.\n",
     "\n",
     "Our grid operators work on the logically rectangular grid of an ocean model, meaning that e.g. differences are evaluated on the 'neighboring' cells in either direction, but even though these cells are adjacent, cells can have different size and geometry.\n",
     "\n",
@@ -464,7 +464,7 @@
    "source": [
     "## Cumulative integration\n",
     "\n",
-    "Using the metric-aware cumulative integration `cumint`, we can calculate the [barotropic transport streamfunction](https://xgcm.readthedocs.io/en/latest/example_mitgcm.html#Barotropic-Transport-Streamfunction) even easier and more intuitive in one line:"
+    "Using the metric-aware cumulative integration `cumint`, we can calculate the [barotropic transport streamfunction](https://xgcm.readthedocs.io/en/latest/xgcm-examples/02_mitgcm/#barotropic-transport-streamfunction) even easier and more intuitive in one line:"
    ]
   },
   {
@@ -536,13 +536,13 @@
     "\n",
     "At it's core, `derivative` is based on `diff`, which shifts a data array \n",
     "to a new grid point, as shown\n",
-    "[here](https://xgcm.readthedocs.io/en/latest/grids.html#core-grid-operations-diff-interp-and-cumsum).\n",
+    "[here](https://xgcm.readthedocs.io/en/latest/grids/#core-grid-operations-diff-interp-and-cumsum).\n",
     "Because of this shifting, we need to either define new metrics which live at the right points on the grid, \n",
     "or first interpolate the desired quantities, anticipating the shift.\n",
     "Here we choose the latter, and interpolate velocities and temperature onto the vertical cell faces of the grid \n",
     "cells.\n",
     "The resulting quantities are in line with the vertical velocity `w`, which is shown in the vertical grid of the C \n",
-    "grid [here](https://xgcm.readthedocs.io/en/latest/grids.html#general-concepts)."
+    "grid [here](https://xgcm.readthedocs.io/en/latest/grids/#general-concepts)."
    ]
   },
   {
@@ -560,7 +560,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The subscript \"l\" is used to denote a leftward shift on the vertical axis, following [this nomenclature](https://xgcm.readthedocs.io/en/latest/grids.html#axes-and-positions).\n",
+    "The subscript \"l\" is used to denote a leftward shift on the vertical axis, following [this nomenclature](https://xgcm.readthedocs.io/en/latest/grids/#axis-positions).\n",
     "\n",
     "As a first example, we show zonal velocity shear in the top layer, which is the finite difference version of: \n",
     "\n",
@@ -743,7 +743,7 @@
     "Keep in mind that this is different from \n",
     "[finite volume differencing schemes](https://mitgcm.readthedocs.io/en/latest/algorithm/finitevol-meth.html) \n",
     "as used in many ocean models.\n",
-    "See [this section](https://xgcm.readthedocs.io/en/latest/example_mitgcm.html#Divergence) \n",
+    "See [this section](https://xgcm.readthedocs.io/en/latest/xgcm-examples/02_mitgcm/#divergence) \n",
     "of documentation for some examples of how xgcm can be helpful in performing these operations.\n",
     "\n",
     "</div>"
@@ -787,7 +787,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we show temperature interpolated in the X direction: from the tracer location to where zonal velocity is located, i.e. from `t` to `u` [in the horizontal view of the C grid shown here](https://xgcm.readthedocs.io/en/latest/grids.html)."
+    "Here we show temperature interpolated in the X direction: from the tracer location to where zonal velocity is located, i.e. from `t` to `u` [in the horizontal view of the C grid shown here](https://xgcm.readthedocs.io/en/latest/grids/)."
    ]
   },
   {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ and install it using pip:
 pip install git+https://github.com/xgcm/xgcm.git
 ```
 
-More comprehensive instructions for installing a development environment can be found in the [Contributor Guide](https://xgcm.readthedocs.io/en/latest/contributor_guide.html).
+More comprehensive instructions for installing a development environment can be found in the [Contributor Guide](https://xgcm.readthedocs.io/en/latest/contributor_guide/).
 
 Users are encouraged to [fork](https://help.github.com/articles/fork-a-repo/)
 xgcm and submit [issues] and [pull requests].

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -226,7 +226,7 @@
 
 - Added documentation on boundary conditions ([#273](https://github.com/xgcm/xgcm/issues/273), [#325](https://github.com/xgcm/xgcm/pull/325))
   By [Romain Caneill](https://github.com/rcaneill).
-- Updated metrics documentation for new methods in [Grid Metrics](https://xgcm.readthedocs.io/en/latest/grid_metrics.html).
+- Updated metrics documentation for new methods in [Grid Metrics](https://xgcm.readthedocs.io/en/latest/grid_metrics/).
   By [Dianne Deauna](https://github.com/jdldeauna).[^siparcs]
 
 ### Internal Changes
@@ -258,7 +258,7 @@
 
 ### Documentation
 
-- Updated Realistic Data examples in [Transforming Vertical Coordinates](https://xgcm.readthedocs.io/en/latest/transform.html) ([#322](https://github.com/xgcm/xgcm/pull/322))
+- Updated Realistic Data examples in [Transforming Vertical Coordinates](https://xgcm.readthedocs.io/en/latest/transform/) ([#322](https://github.com/xgcm/xgcm/pull/322))
   By [Dianne Deauna](https://github.com/jdldeauna).[^siparcs]
 
 - Migrated model example notebooks to [xgcm-examples](https://github.com/xgcm/xgcm-examples) which integrates with [pangeo gallery](https://gallery.pangeo.io/repos/xgcm/xgcm-examples/) ([#294](https://github.com/xgcm/xgcm/pull/294))
@@ -312,7 +312,7 @@
 
 ## v0.3.0 (31 January 2020) {#whats-new-0-4-0}
 
-This release adds support for [model grid metrics](https://xgcm.readthedocs.io/en/latest/grid_metrics.html) , bug fixes and extended documentation.
+This release adds support for [model grid metrics](https://xgcm.readthedocs.io/en/latest/grid_metrics/) , bug fixes and extended documentation.
 
 ### Breaking changes
 


### PR DESCRIPTION
The documentation moved from Sphinx (`*.html` pages) to mkdocs-material, which serves directory-style URLs. Several internal `xgcm.readthedocs.io` links still pointed at the old Sphinx paths and now 404. This PR updates them to the current scheme. Every replacement was verified against the live site with a fetch before changing.

### Changes by category

**`*.html` -> `*/` page-stem URLs** (page exists, slug unchanged):
- `docs/installation.md` — `contributor_guide.html` -> `contributor_guide/`
- `.github/ISSUE_TEMPLATE/release_reminder.md` — `contributor_guide.html#...` -> `contributor_guide/#...`
- `docs/whats-new.md` — `grid_metrics.html` -> `grid_metrics/` (x2), `transform.html` -> `transform/` (URL targets only; historical text and PR/issue numbers untouched)
- `docs/grid_metrics.ipynb` — `grid_topology.html` -> `grid_topology/`, `grids.html` -> `grids/`

**MITgcm example page moved + anchor slugs changed** in `docs/grid_metrics.ipynb`:
- `example_mitgcm.html` is now the example notebook at `xgcm-examples/02_mitgcm/`
- `#Divergence` -> `#divergence`
- `#Barotropic-Transport-Streamfunction` -> `#barotropic-transport-streamfunction`

**Anchor slug renamed** in `docs/grid_metrics.ipynb`:
- `grids.html#axes-and-positions` -> `grids/#axis-positions` (the heading anchor changed under mkdocs)

### Notes
- The notebook edit changes only markdown-cell link URLs; no outputs, metadata, or execution counts were touched and the JSON remains valid.
- Third-party links that still resolve were left as-is (e.g. the MITgcm manual `node31.html`, the `mitgcm.readthedocs.io` finite-volume page, and `xarray.pydata.org`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)