### PR TITLE
ci: add aggregated 'All tests passed' merge gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,11 +109,15 @@ jobs:
         if: >-
           ${{ contains(needs.*.result, 'failure')
            || contains(needs.*.result, 'cancelled') }}
+        env:
+          CACHE_RESULT: ${{ needs.cache-pixi-lock.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          ZIZMOR_RESULT: ${{ needs.zizmor.result }}
         run: |
           echo "One or more required jobs did not succeed:"
-          echo "  cache-pixi-lock: ${{ needs.cache-pixi-lock.result }}"
-          echo "  test:            ${{ needs.test.result }}"
-          echo "  zizmor:          ${{ needs.zizmor.result }}"
+          echo "  cache-pixi-lock: $CACHE_RESULT"
+          echo "  test:            $TEST_RESULT"
+          echo "  zizmor:          $ZIZMOR_RESULT"
           exit 1
       - name: All required jobs succeeded
         run: echo "All required jobs passed."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,9 @@ jobs:
     needs: ["cache-pixi-lock"]
     if: github.repository == 'xgcm/xgcm'
     runs-on: ${{ matrix.os }}
+    # nightly runs against git-tip xarray/dask/numpy; let it fail without
+    # failing the overall `test` job (and therefore the merge gate).
+    continue-on-error: ${{ matrix.pixi-env == 'test-nightly' }}
     permissions:
       contents: read
     timeout-minutes: 60
@@ -92,6 +95,28 @@ jobs:
           env_vars: PIXI_ENV
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  all-tests:
+    name: All tests passed
+    # Single aggregated gate to use as the required status check on `master`,
+    # so the matrix can change without touching branch-protection settings.
+    needs: ["cache-pixi-lock", "test", "zizmor"]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: >-
+          ${{ contains(needs.*.result, 'failure')
+           || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more required jobs did not succeed:"
+          echo "  cache-pixi-lock: ${{ needs.cache-pixi-lock.result }}"
+          echo "  test:            ${{ needs.test.result }}"
+          echo "  zizmor:          ${{ needs.zizmor.result }}"
+          exit 1
+      - name: All required jobs succeeded
+        run: echo "All required jobs passed."
 
   zizmor:
     name: GHA Security Analysis using Zizmor


### PR DESCRIPTION
## What

Adds a single `all-tests` job (`needs: [cache-pixi-lock, test, zizmor]`, `if: always()`) that succeeds only when all of those jobs succeed, and fails otherwise. This is intended to become the **sole required status check** on `master`.

It also marks the `test-nightly` matrix leg `continue-on-error`, so breakage in git-tip xarray/dask/numpy still shows red on its own line but no longer fails the overall `test` job (and therefore won't block merges).

## Why

Per #692, required status checks were never re-added after the Pixi/CI rename in #691. Requiring every matrix entry by name is brittle — adding or dropping a Python version silently changes what's enforced and requires editing branch protection each time. Gating on one aggregator job decouples the required-check config from the matrix.

## Rollout (after merge)

Once this lands and `All tests passed` reports on `master`, set it as the only required check:

```bash
gh api --method PATCH \
  repos/xgcm/xgcm/branches/master/protection/required_status_checks \
  --input - <<'JSON'
{"strict": false, "checks": [{"context": "All tests passed"}]}
JSON
```

Closes #692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)