### PR TITLE
Fix blackdoc hook: bump blackdoc to v0.4.6 + black to 26.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,10 +27,10 @@ repos:
         types_or: [jupyter]
       - id: ruff-format
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.4.1
+    rev: v0.4.6
     hooks:
       - id: blackdoc
-        additional_dependencies: ["black==22.3.0"]
+        additional_dependencies: ["black==26.5.1"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.18.1
     hooks:

--- a/docs/boundary_conditions.md
+++ b/docs/boundary_conditions.md
@@ -101,7 +101,7 @@ g_perio = grid_perio.diff(g, "X").rename("periodic")
 ```
 
 ```python
-for (i, var) in enumerate([g_extend, g_fill_0, g_fill_2, g_perio]):
+for i, var in enumerate([g_extend, g_fill_0, g_fill_2, g_perio]):
     var.plot.line(marker="o", label=var.name)
 plt.grid(True)
 plt.legend()

--- a/docs/grid_ufuncs.md
+++ b/docs/grid_ufuncs.md
@@ -191,7 +191,7 @@ from typing import Annotated
 ```python
 @as_grid_ufunc()
 def diff_center_to_left(
-    a: Annotated[np.ndarray, "ax1:center"]
+    a: Annotated[np.ndarray, "ax1:center"],
 ) -> Annotated[np.ndarray, "ax1:left"]:
     return diff_forward(a)
 ```


### PR DESCRIPTION
## Problem

The `blackdoc` pre-commit hook pins `black==22.3.0` in `additional_dependencies`. The **pre-commit.ci autoupdate bot only bumps each hook's `rev:`** — it never touches `additional_dependencies`. So when it tries to bump blackdoc `v0.4.1 → v0.4.6` (which requires `black>=24.4`), installing the hook env fails:

```
ERROR: Cannot install black==22.3.0 and blackdoc==0.4.6 because these
package versions have conflicting dependencies. ResolutionImpossible
```

This blocks every autoupdate PR — see #677, whose `pre-commit.ci` check has been red on exactly this.

## Why bump both

blackdoc and black have to move as a pair:
- **v0.4.1** only runs against *old* black — with `black==26.5.1` it crashes at runtime (`decode_bytes() missing required argument 'mode'`; black changed the signature).
- **v0.4.6** requires `black>=24.4`.

So fixing only the black pin (keeping blackdoc v0.4.1) doesn't work, and bumping only blackdoc (the bot's behavior) doesn't work either. This PR bumps **both** to a verified-compatible pair, so master carries a consistent config and the bot's future blackdoc `rev` bumps resolve cleanly.

## Changes
- `.pre-commit-config.yaml`: blackdoc `v0.4.1 → v0.4.6`, `black==22.3.0 → black==26.5.1`
- `docs/boundary_conditions.md`, `docs/grid_ufuncs.md`: the two doctest reformats the newer black produces (`for (i, var)` → `for i, var`; a magic trailing comma), so the hook passes clean rather than auto-fixing.

## Verification
- `blackdoc --check` (v0.4.6 + black 26.5.1) passes on all 34 files.
- `pixi run -e docs mkdocs build --strict` builds successfully.

## Note on recurrence
A hard black pin will eventually go stale again the next time a blackdoc release raises its black floor (the bot won't update `additional_dependencies`). If you'd prefer this not recur, switch the pin to a floor like `black>=24.4` (mirroring blackdoc's own requirement) or drop it entirely so blackdoc pulls a compatible black itself — at the cost of black's version no longer being fully reproducible. Kept as a pin here to match the existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)