### PR TITLE
docs: remove nav entry for deleted autogenerate example

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,7 +81,6 @@ nav:
       - MITgcm ECCOv4: xgcm-examples/01_eccov4.ipynb
       - MOM6: xgcm-examples/03_MOM6.ipynb
       - NEMO: xgcm-examples/04_nemo_idealized.ipynb
-      - Generate missing C-grid coordinates: xgcm-examples/05_autogenerate.ipynb
   - "What's New": whats-new.md
   - Contributor Guide: contributor_guide.md
   - API: api.md


### PR DESCRIPTION
## What

1. Removes the mkdocs nav entry `Generate missing C-grid coordinates: xgcm-examples/05_autogenerate.ipynb`.
2. Bumps the `docs/xgcm-examples` submodule from `e41814e` to `6c9b824` (current `xgcm/xgcm-examples` master), which includes the deletion of `05_autogenerate.ipynb` (xgcm/xgcm-examples#31, now merged) plus the other example updates merged upstream since the previous pin.

## Why

The example demonstrated the autogenerate API (`xgcm.autogenerate.generate_grid_ds` / `Grid.autogenerate`) removed in #557 (v0.9.0). The notebook no longer runs against current xgcm and has been removed from the examples repo. This PR drops both the nav reference and the pinned submodule content for it, so the docs no longer build/point at a deleted example.

The `whats-new.md` entry documenting the #557 removal is intentionally left in place.

## Note

The submodule bump advances across several upstream example PRs (not only the autogenerate deletion), since the previous pin (`e41814e`) was well behind `xgcm-examples` master — so the rendered `01`–`04` examples also refresh to their current upstream state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018C71N1nWGCs8kbNAuz9QxH