### PR TITLE
docs: fix stale changelog — split released v0.9.0 from new v0.10.0 section

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,37 +1,13 @@
 # What's New
 
-## v0.9.0 (unreleased) {#whats-new-0-9-0}
+## v0.10.0 (unreleased) {#whats-new-0-10-0}
 
 
 ### New Features
 
-- Methods for autoparsing of dataset metadata to construct a `xgcm.Grid` class have been added.
-  Currently these include restructred functionality for the COMODO conventions (already in xgcm) and the
-  addition of SGRID conventions ([#109](https://github.com/xgcm/xgcm/issues/109), [#559](https://github.com/xgcm/xgcm/pull/559)).
-  By [Jack Atkinson](https://github.com/jatkinson1000).
-
-- Vertical coordinate transformations are now also supported for multi-dimensional targets, for example a
-  terrain-following (spatially varying) vertical coordinate. This feature currently only works with the linear
-  interpolation method ([#614](https://github.com/xgcm/xgcm/issues/614), [#642](https://github.com/xgcm/xgcm/pull/642)).
-  By [Nora Loose](https://github.com/noraloose).
-
 ### Breaking Changes
 
-- All computation methods on the `xgcm.Axis` class have been removed, in favour of using the corresponding
-  methods on the `xgcm.Grid` object. The `xgcm.Axis` class has also been removed from public API.
-  ([#405](https://github.com/xgcm/xgcm/issues/405), [#557](https://github.com/xgcm/xgcm/pull/557)).
-  By [Thomas Nicholas](https://github.com/tomnicholas).
-
-- All functionality for generating c-grid dimensions on incomplete datasets via `Grid.autogenerate`,  was removed ([#557](https://github.com/xgcm/xgcm/pull/557)).
-   By [Julius Busecke](https://github.com/jbusecke).
-
 ### Internal Changes
-
-- Switch CI environment setup to micromamba ([#576](https://github.com/xgcm/xgcm/issues/576), [#577](https://github.com/xgcm/xgcm/pull/577)).
-  By [Julius Busecke](https://github.com/jbusecke).
-
-- pre-commit autoupdate frequency reduced ([#563](https://github.com/xgcm/xgcm/pull/563)).
-  By [Julius Busecke](https://github.com/jbusecke).
 
 - Migrate development workflow to Pixi ([#691](https://github.com/xgcm/xgcm/pull/691))
   By [Nick Hodgskin](https://github.com/VeckoTheGecko).
@@ -77,8 +53,50 @@
   ([#708](https://github.com/xgcm/xgcm/issues/708)).
   By [Henri Drake](https://github.com/hdrake).
 
+- Fix non-deterministic, hash-seed-dependent halo values in face-connection padding that could yield
+  incorrect results across a face-connection seam between runs ([#713](https://github.com/xgcm/xgcm/pull/713)).
+  By [Henri Drake](https://github.com/hdrake).
+
+## v0.9.0 (2025/08/20) {#whats-new-0-9-0}
+
+
+### New Features
+
+- Methods for autoparsing of dataset metadata to construct a `xgcm.Grid` class have been added.
+  Currently these include restructred functionality for the COMODO conventions (already in xgcm) and the
+  addition of SGRID conventions ([#109](https://github.com/xgcm/xgcm/issues/109), [#559](https://github.com/xgcm/xgcm/pull/559)).
+  By [Jack Atkinson](https://github.com/jatkinson1000).
+
+- Vertical coordinate transformations are now also supported for multi-dimensional targets, for example a
+  terrain-following (spatially varying) vertical coordinate. This feature currently only works with the linear
+  interpolation method ([#614](https://github.com/xgcm/xgcm/issues/614), [#642](https://github.com/xgcm/xgcm/pull/642)).
+  By [Nora Loose](https://github.com/noraloose).
+
+### Breaking Changes
+
+- All computation methods on the `xgcm.Axis` class have been removed, in favour of using the corresponding
+  methods on the `xgcm.Grid` object. The `xgcm.Axis` class has also been removed from public API.
+  ([#405](https://github.com/xgcm/xgcm/issues/405), [#557](https://github.com/xgcm/xgcm/pull/557)).
+  By [Thomas Nicholas](https://github.com/tomnicholas).
+
+- All functionality for generating c-grid dimensions on incomplete datasets via `Grid.autogenerate`,  was removed ([#557](https://github.com/xgcm/xgcm/pull/557)).
+   By [Julius Busecke](https://github.com/jbusecke).
+
+### Internal Changes
+
+- Switch CI environment setup to micromamba ([#576](https://github.com/xgcm/xgcm/issues/576), [#577](https://github.com/xgcm/xgcm/pull/577)).
+  By [Julius Busecke](https://github.com/jbusecke).
+
+- pre-commit autoupdate frequency reduced ([#563](https://github.com/xgcm/xgcm/pull/563)).
+  By [Julius Busecke](https://github.com/jbusecke).
+
+### Documentation
+
+### Bugfixes
+
 - Fix bug in `xgcm.transform.transform` that violated tracer conservation when using conservative interpolation in the presence of nans. ([#635](https://github.com/xgcm/xgcm/pull/635))
   By [Julius Busecke](https://github.com/jbusecke).
+
 - Fix bug in `xgcm.padding._maybe_rename_grid_positions` where dimensions were assumed to have coordinate
   values leading to errors with ECCO data. ([#531](https://github.com/xgcm/xgcm/issues/531), [#595](https://github.com/xgcm/xgcm/issues/595), [#597](https://github.com/xgcm/xgcm/pull/597)).
   By [Julius Busecke](https://github.com/jbusecke).
@@ -90,9 +108,6 @@
   By [Julius Busecke](https://github.com/jbusecke).
 
 - Fix bug that did not allow to create grids with faceconnections if the face dimension was coordinate-less. ([#616](https://github.com/xgcm/xgcm/issues/616), [#616](https://github.com/xgcm/xgcm/pull/616)).
-  By [Julius Busecke](https://github.com/jbusecke).
-
-- Fix bug in `xgcm.padding._maybe_rename_grid_positions` where dimensions were assumed to have coordinate values leading to errors with ECCO data. ([#531](https://github.com/xgcm/xgcm/issues/531), [#595](https://github.com/xgcm/xgcm/issues/595), [#597](https://github.com/xgcm/xgcm/pull/597)).
   By [Julius Busecke](https://github.com/jbusecke).
 
 ## v0.8.1 (2022/11/22) {#whats-new-0-8-1}


### PR DESCRIPTION
## What

The `docs/whats-new.md` header still read **`v0.9.0 (unreleased)`** even though v0.9.0 shipped on **2025-08-20**. As a result the section mixed entries that were *already released* in v0.9.0 with work merged *after* the release, and it had a duplicated bugfix entry. This PR corrects the changelog with no code changes.

## Changes

- **Mark v0.9.0 as released** (`## v0.9.0 (2025/08/20)`), keeping only the entries actually in that release: SGRID autoparse (#559), multi-dimensional transform targets (#642), the `Axis`-method and `autogenerate` removals (#557), and bugfixes #635 / #597 / #602 / #631 / #616.
- **Open a new `## v0.10.0 (unreleased)` section** for post-release work merged to `master`: Pixi migration (#691), import-speed improvement (#697), mkdocs migration (#691), and bugfixes #533, #496/#575, #581, #708.
- **Dedupe** the doubled ECCO `_maybe_rename_grid_positions` (#597) entry.
- **Add** the missing post-release bugfix for non-deterministic, hash-seed-dependent face-connection halos (#713).

## Why v0.10.0

Several of the post-release changes are user-facing (new behavior in #533 and #496/#575) and more features are queued, so the next release is shaping up to be a minor bump rather than a patch. This gives it a correctly-labeled landing section. The in-flight north-fold feature (#711) is intentionally **not** included here — its changelog entry travels with that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)