### PR TITLE
MAINT: Bump Pixi version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PIXI_VERSION: "v0.63.0"
+  PIXI_VERSION: "v0.72.0"
 
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ name = "xgcm"
 version = "dynamic" # dynamic versioning needs better support in pixi https://github.com/prefix-dev/pixi/issues/2923#issuecomment-2598460666 . Putting `version = "dynamic"` here for now until pixi recommends something else.
 
 [tool.pixi.package.build]
-backend = { name = "pixi-build-python", version = "0.4.*" }
+backend = { name = "pixi-build-python", version = "0.7.*" }
 
 [tool.pixi.package.host-dependencies]
 setuptools = "*"

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,15 +10,14 @@ build:
     python: "latest"
   jobs:
     create_environment:
-      # Pin pixi to a known-good version instead of `latest`. pixi 0.71.x ships
-      # a `pixi-build-api-version` that the pinned `pixi-build-python = "0.4.*"`
-      # build backend (in pyproject.toml) can no longer resolve against, so
-      # `pixi install -e docs` fails to solve the environment. 0.70.2 is the
-      # last version that produced a successful build. See the solver error:
-      # https://app.readthedocs.org/projects/xgcm/builds/33330391/
+      # Pin pixi to a known-good version instead of `latest`, and keep it in sync
+      # with the `pixi-build-python` backend in pyproject.toml (they negotiate over
+      # a private `pixi-build-api-version`; a mismatched pair fails to solve with
+      # "no candidates for pixi-build-api-version"). The `0.7.*` backend needs a
+      # recent pixi, so this is pinned to match `PIXI_VERSION` in ci.yaml.
       - asdf plugin add pixi
-      - asdf install pixi 0.70.2
-      - asdf global pixi 0.70.2
+      - asdf install pixi 0.72.0
+      - asdf global pixi 0.72.0
     install:
       - pixi install -e docs
     build:


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

Latest Pixi (0.72.0) wasn't working with the `0.4.*` build backends. This PR updates to the `0.7.*` backend and also bumps the pixi version used in CI.

I think we can remove the PIXI_VERSION lock in CI entirely, but I'll leave that decision up to you.

 - [x] Closes None