### PR TITLE
ci: fix PyPI build workflow push trigger (main → master)

### DIFF
--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -2,7 +2,7 @@ name: Build and Upload xGCM to PyPI
 on:
   push:
     branches:
-      - "main"
+      - "master"
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
## Summary

The `push` trigger in `.github/workflows/pythonpublish.yaml` targeted branch `main`, but this repo's default branch is `master`. As a result the build-sanity run **never fired on push-to-default** — it only ran on pull requests and releases.

This one-line change points the `push` trigger at `master` so merges to the default branch exercise the `python -m build` + `twine check` sanity build.

## Impact

- **No effect on publishing.** Actual PyPI upload is gated on `release: published` (`if: github.event_name == 'release'`) and is unchanged.
- Adds a build run on push to `master` (matching the intent of the existing trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)