### PR TITLE
Fix conservative-transform multi-dim guard testing dim-name length

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -22,6 +22,12 @@
 
 ### Bugfixes
 
+- Fix `Grid.transform(..., method="conservative")` falsely raising `NotImplementedError`
+  ("not yet supported for multi-dimensional targets") when a 1-dimensional target was combined
+  with an explicit `target_dim` longer than one character: the guard tested the length of the
+  dimension *name* instead of the number of target dimensions.
+  By [Henri Drake](https://github.com/hdrake).
+
 - Preserve the input DataArray's dimension order in the output of `apply_as_grid_ufunc`
   (and the `Grid.apply_as_grid_ufunc` method). Previously `xarray.apply_ufunc` moved the
   operated-on core dimension to the end and never moved it back, so an input with dims

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -25,7 +25,8 @@
 - Fix `Grid.transform(..., method="conservative")` falsely raising `NotImplementedError`
   ("not yet supported for multi-dimensional targets") when a 1-dimensional target was combined
   with an explicit `target_dim` longer than one character: the guard tested the length of the
-  dimension *name* instead of the number of target dimensions.
+  dimension *name* instead of the number of target dimensions
+  ([#741](https://github.com/xgcm/xgcm/pull/741)).
   By [Henri Drake](https://github.com/hdrake).
 
 - Preserve the input DataArray's dimension order in the output of `apply_as_grid_ufunc`

--- a/xgcm/test/test_transform.py
+++ b/xgcm/test/test_transform.py
@@ -1083,6 +1083,29 @@ def test_conservative_interp_error_if_multidim_target_dim(conservative_multidim_
 
 
 @pytest.mark.skipif(numba is None, reason="numba required")
+def test_conservative_transform_explicit_target_dim():
+    # Regression test: the multi-dimensional-target guard used to check
+    # len(target_dim) — the length of the dimension *name* — so a 1D target
+    # combined with an explicit target_dim longer than one character falsely
+    # raised NotImplementedError.
+    source, grid_kwargs, target, transform_kwargs, expected, error_flag = (
+        construct_test_source_data(cases["conservative_depth_depth_rename"])
+    )
+
+    axis = list(grid_kwargs["coords"].keys())[0]
+
+    grid = Grid(source, periodic=False, **grid_kwargs)
+
+    (target_dim,) = target.dims
+    assert len(target_dim) > 1
+    transformed = grid.transform(
+        source.data, axis, target, target_dim=target_dim, **transform_kwargs
+    )
+    output_name = "data" + transform_kwargs.get("suffix", "")
+    xr.testing.assert_allclose(transformed, expected[output_name])
+
+
+@pytest.mark.skipif(numba is None, reason="numba required")
 def test_conservative_interp_warn_if_no_cell_bounds():
     (
         source,

--- a/xgcm/transform.py
+++ b/xgcm/transform.py
@@ -466,7 +466,7 @@ def transform(
         )
     elif method == "conservative":
         if isinstance(target, xr.DataArray):
-            if target_dim is not None and len(target_dim) > 1:
+            if len(target.dims) > 1:
                 raise NotImplementedError(
                     "Conservative transformation is not yet supported for multi-dimensional targets."
                 )


### PR DESCRIPTION
## What

`Grid.transform(..., method="conservative")` falsely raised `NotImplementedError` ("Conservative transformation is not yet supported for multi-dimensional targets") whenever a **1-dimensional** target was combined with an explicit `target_dim` longer than one character.

## Why

The guard tested `len(target_dim) > 1` — the length of the dimension *name* string — instead of the number of target dimensions. It now tests `len(target.dims) > 1`, which also correctly catches multi-dimensional targets when `target_dim` is omitted (previously those slipped past the guard and failed obscurely downstream).

Found while scoping #666 (real multi-dim conservative support, which stays a separate feature PR); part of the #733 v1.0.0 push.

## Tests

- New regression test `test_conservative_transform_explicit_target_dim`: 1-D target with explicit multi-char `target_dim` no longer raises and matches the expected conservative result.
- Existing `test_conservative_interp_error_if_multidim_target_dim` (genuinely multi-dim targets) still passes — now for the right reason.
- Full suite green locally (`pixi run tests`; only unrelated local untracked-file tests excluded).

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes documented in `docs/whats-new.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)