### PR TITLE
docs: document the EffVer versioning policy in the contributor guide

### DIFF
--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -51,13 +51,17 @@ pixi run docs-serve
 ```
 This will start a live preview running on `http://127.0.0.1:8000/`
 
+## Versioning policy
+
+xgcm uses [Intended Effort Versioning (EffVer)](https://jacobtomlinson.dev/effver/): version numbers are `MACRO.MESO.MICRO`. A **MACRO** bump signals that adopting the release may require a large effort from users; a **MESO** bump signals that some effort may be required; a **MICRO** bump signals that little to no effort is expected. Version numbers communicate the *intended* upgrade effort, not a strict API-compatibility guarantee.
+
 ## How to release a new version of xgcm (for maintainers only)
 
 The process of releasing at this point is very easy.
 
 We need only two things: A PR to update the documentation and a release on github.
 
-1. Make sure that all the new features/bugfixes etc are appropriately documented in `docs/whats-new.md`, add the date to the current release and make an empty (unreleased) entry for the next minor release as a PR.
+1. Make sure that all the new features/bugfixes etc are appropriately documented in `docs/whats-new.md`, add the date to the current release and make an empty (unreleased) entry for the next release as a PR. Choose the next version number according to the [versioning policy](#versioning-policy) above.
 2. Navigate to the 'tags' symbol on the repos main page, click on 'Releases' and on 'Draft new release' on the right. Add the version number and a short description and save the release.
 
 From here the github actions take over and package things for [Pypi](https://pypi.org/project/xgcm/).

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -53,7 +53,7 @@ This will start a live preview running on `http://127.0.0.1:8000/`
 
 ## Versioning policy
 
-xgcm uses [Intended Effort Versioning (EffVer)](https://jacobtomlinson.dev/effver/): version numbers are `MACRO.MESO.MICRO`. A **MACRO** bump signals that adopting the release may require a large effort from users; a **MESO** bump signals that some effort may be required; a **MICRO** bump signals that little to no effort is expected. Version numbers communicate the *intended* upgrade effort, not a strict API-compatibility guarantee.
+xgcm uses [Intended Effort Versioning (EffVer)](https://jacobtomlinson.dev/effver/): version numbers are `MACRO.MESO.MICRO`. A **MACRO** bump signals that adopting the release may require a large effort from users; a **MESO** bump signals that some effort may be required; a **MICRO** bump signals that little to no effort is expected. Version numbers communicate the *intended* upgrade effort, not a strict API-compatibility guarantee. (For releases below 1.0.0, the segments shift one position per EffVer's zero-version guidance: `0.MACRO.MESO`.)
 
 ## How to release a new version of xgcm (for maintainers only)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -20,6 +20,11 @@
 - Migrate documentation to mkdocs ([#691](https://github.com/xgcm/xgcm/pull/691))
   By [Nick Hodgskin](https://github.com/VeckoTheGecko).
 
+- xgcm now follows [Intended Effort Versioning (EffVer)](https://jacobtomlinson.dev/effver/); the policy
+  is documented in the contributor guide and advertised by a README badge
+  ([#679](https://github.com/xgcm/xgcm/issues/679), [#680](https://github.com/xgcm/xgcm/pull/680), [#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  By [Nick Hodgskin](https://github.com/VeckoTheGecko) and [Henri Drake](https://github.com/hdrake).
+
 ### Bugfixes
 
 - Preserve the input DataArray's dimension order in the output of `apply_as_grid_ufunc`

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -22,7 +22,7 @@
 
 - xgcm now follows [Intended Effort Versioning (EffVer)](https://jacobtomlinson.dev/effver/); the policy
   is documented in the contributor guide and advertised by a README badge
-  ([#679](https://github.com/xgcm/xgcm/issues/679), [#680](https://github.com/xgcm/xgcm/pull/680), [#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  ([#679](https://github.com/xgcm/xgcm/issues/679), [#680](https://github.com/xgcm/xgcm/pull/680), [#742](https://github.com/xgcm/xgcm/pull/742)).
   By [Nick Hodgskin](https://github.com/VeckoTheGecko) and [Henri Drake](https://github.com/hdrake).
 
 ### Bugfixes


### PR DESCRIPTION
## What

Companion to #680 (which adds the EffVer README badge): documents what adopting [EffVer](https://jacobtomlinson.dev/effver/) actually means for contributors and maintainers.

- New **Versioning policy** section in `docs/contributor_guide.md` explaining MACRO/MESO/MICRO bump semantics.
- Release checklist no longer says "next **minor** release" (SemVer language); it now points at the versioning policy.
- `docs/whats-new.md` entry recording the EffVer adoption (resolves the decision in #679).

## Why

A badge alone doesn't tell contributors what version bumps signify. With the v1.0.0 push (#733) requiring the versioning policy to be recorded before tagging, this makes the decision explicit in the docs.

Can merge independently of #680, but they belong together.

## Tests

Docs-only: `pixi run -e docs docs-build` clean, `pixi run lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)