### PR TITLE
Remove `Axis` from the public API

### DIFF
--- a/docs/grids.md
+++ b/docs/grids.md
@@ -82,7 +82,7 @@ one extra point. These positions are visualized in the figure below.
 
 *The different possible positions of a variable `f` along an axis.*
 
-xgcm represents an axis internally using the `xgcm.Axis` class.
+xgcm represents an axis internally using the `Axis` class (`xgcm.axis.Axis`).
 
 Although it is technically possible to create an `Axis` directly, the recommended way to
 to use xgcm is by creating a single `xgcm.Grid` object, containing multiple axes

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -7,6 +7,12 @@
 
 ### Breaking Changes
 
+- `Axis` is no longer importable from the top-level `xgcm` namespace, making effective the
+  removal announced in v0.9.0; internal use continues via `xgcm.axis.Axis`
+  ([#405](https://github.com/xgcm/xgcm/issues/405), [#557](https://github.com/xgcm/xgcm/pull/557),
+  [#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  By [Henri Drake](https://github.com/hdrake).
+
 ### Internal Changes
 
 - Migrate development workflow to Pixi ([#691](https://github.com/xgcm/xgcm/pull/691))

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,7 +10,7 @@
 - `Axis` is no longer importable from the top-level `xgcm` namespace, making effective the
   removal announced in v0.9.0; internal use continues via `xgcm.axis.Axis`
   ([#405](https://github.com/xgcm/xgcm/issues/405), [#557](https://github.com/xgcm/xgcm/pull/557),
-  [#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  [#743](https://github.com/xgcm/xgcm/pull/743)).
   By [Henri Drake](https://github.com/hdrake).
 
 ### Internal Changes

--- a/xgcm/__init__.py
+++ b/xgcm/__init__.py
@@ -3,5 +3,5 @@ try:
 except ImportError:
     __version__ = "unknown"
 
-from .grid import Axis, Grid
+from .grid import Grid
 from .grid_ufunc import apply_as_grid_ufunc, as_grid_ufunc


### PR DESCRIPTION
## What

- Removes `Axis` from the top-level `xgcm` import (`xgcm/__init__.py`), keeping `Grid`. `Axis` remains importable internally via `xgcm.axis.Axis` (and `xgcm.grid` continues to import it for internal use).
- The `Axis` class itself is unchanged.
- Adds a Breaking Changes changelog entry for v0.10.0.

## Why

v0.9.0's changelog already announced this removal ("The `xgcm.Axis` class has also been removed from public API", #405 / #557), and `docs/api.md` / `docs/grids.md` already treat `Axis` as internal — but the top-level import was never actually dropped. This finishes the announced removal ahead of v1.0.0 (#733, roadmap §D).

An audit found no code or docs importing `Axis` from the top level: tests already use `from xgcm.axis import Axis`, and remaining `xgcm.Axis` mentions are conceptual docstring references only.

## Tests

- Full suite green: 4204 passed, 2 skipped, 50 xfailed, 8 xpassed.
- `pre-commit run --all-files` clean.

Completes the public-API portion of #405 / #557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)