### PR TITLE
docs/packaging: reconcile grid_ufuncs metrics note, classifiers, and drop unused future dep

### DIFF
--- a/docs/grid_ufuncs.md
+++ b/docs/grid_ufuncs.md
@@ -317,8 +317,8 @@ For more advanced examples of grid ufuncs, see the page on [Ufunc Examples](ufun
 ## Metrics
 
 !!! note
-    Automatically supplying metrics directly to grid ufuncs is not yet implemented, but will be soon!
-    For now, if you need a metric in your grid ufunc, simply include it as an input and pass it explicitly.
+    Metrics are not automatically supplied to grid ufuncs. If you need a metric in your grid ufunc,
+    include it as an input and pass it explicitly.
     To work with metrics outside of grid ufuncs see the documentation page on metrics.
 
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,7 +11,7 @@
 
 - Advertise Python 3.12 and 3.13 support by adding their `Programming Language :: Python` trove
   classifiers, and drop the unused `future` dependency (the package was never imported; only the
-  stdlib `from __future__` is used) ([#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  stdlib `from __future__` is used) ([#744](https://github.com/xgcm/xgcm/pull/744)).
   By [Henri Drake](https://github.com/hdrake).
 
 - Migrate development workflow to Pixi ([#691](https://github.com/xgcm/xgcm/pull/691))
@@ -24,7 +24,7 @@
 
 - Reword the "Metrics" note in `grid_ufuncs.md` to a stable, non-promissory statement: metrics are
   not automatically supplied to grid ufuncs, so pass any needed metric explicitly as an input
-  ([#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  ([#744](https://github.com/xgcm/xgcm/pull/744)).
   By [Henri Drake](https://github.com/hdrake).
 
 - Migrate documentation to mkdocs ([#691](https://github.com/xgcm/xgcm/pull/691))

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,6 +9,11 @@
 
 ### Internal Changes
 
+- Advertise Python 3.12 and 3.13 support by adding their `Programming Language :: Python` trove
+  classifiers, and drop the unused `future` dependency (the package was never imported; only the
+  stdlib `from __future__` is used) ([#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  By [Henri Drake](https://github.com/hdrake).
+
 - Migrate development workflow to Pixi ([#691](https://github.com/xgcm/xgcm/pull/691))
   By [Nick Hodgskin](https://github.com/VeckoTheGecko).
 
@@ -16,6 +21,11 @@
   By [Nick Hodgskin](https://github.com/VeckoTheGecko).
 
 ### Documentation
+
+- Reword the "Metrics" note in `grid_ufuncs.md` to a stable, non-promissory statement: metrics are
+  not automatically supplied to grid ufuncs, so pass any needed metric explicitly as an input
+  ([#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  By [Henri Drake](https://github.com/hdrake).
 
 - Migrate documentation to mkdocs ([#691](https://github.com/xgcm/xgcm/pull/691))
   By [Nick Hodgskin](https://github.com/VeckoTheGecko).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ classifiers = [
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
 ]
 license = { text = "MIT" }
 keywords = ["pangeo", "simulations", "grids"]
@@ -30,7 +32,6 @@ dependencies = [
     "xarray>=0.20.0",
     "dask",
     "numpy",
-    "future"
 ]
 
 [project.optional-dependencies]
@@ -134,7 +135,6 @@ python = ">=3.9"
 xarray = ">=0.20.0"
 dask = "*"
 numpy = "*"
-future = "*"
 scipy = "*" # TODO: `xgcm/test/test_grid_ufunc.py::TestGridUFuncNoPadding::test_1d_changing_size_dask_parallelized` failing if scipy isn't put here. Is scipy a core dependency? If no - move to `feature.extra` and fix test.
 
 [tool.pixi.dependencies]


### PR DESCRIPTION
Small docs/packaging reconciliation for the v1.0.0 push (roadmap #733, section D).

### Changes
- **`docs/grid_ufuncs.md`**: The "Metrics" note promised that automatically supplying metrics to grid ufuncs was "not yet implemented, but will be soon!" That feature is deferred to 1.x (not 1.0), so this rewords it into a stable, non-promissory statement: metrics are not automatically supplied to grid ufuncs; include any needed metric as an explicit input. The existing workaround text is preserved.
- **`pyproject.toml`**:
  - Add `Programming Language :: Python :: 3.12` and `:: 3.13` trove classifiers. Both are exercised by the pixi test envs (`test-py312`, `test-py313`, and the py314-based `test-latest`/`test-core`). `requires-python = ">=3.9"` and the Production/Stable classifier are unchanged.
  - Drop the unused `future` runtime dependency. Nothing imports the `future` package anywhere in the codebase — the only `future` references are the stdlib `from __future__ import annotations` and unrelated "future releases" strings. Removed from both `[project].dependencies` and the in-sync pixi run-dependencies section.
- **`docs/whats-new.md`**: changelog entries under Documentation and Internal Changes.

### Verification
- `pixi run -e docs docs-build` — clean build.
- `pixi run lint` — all hooks pass.
- `pixi run tests` — 4204 passed, 2 skipped, 50 xfailed, 8 xpassed (confirms nothing relied on the `future` package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)