### PR TITLE
Remove deprecated `keep_coords` kwarg

### DIFF
--- a/docs/grids.md
+++ b/docs/grids.md
@@ -367,15 +367,15 @@ grid.cumsum(da_diff, "X")
 Which is approximately equal to the original `da`, modulo the numerical errors
 accrued due to the discretization of the data.
 
-By default, these grid operations will drop any coordinate that are not
-dimensions. The keep_coords argument allow to preserve compatible coordinates.
-For example:
+These grid operations preserve any coordinate that is compatible with the
+output (i.e. defined on dimensions present in the result), including
+non-dimension coordinates. For example:
 
 ```python
 da2 = da + xr.Dataset(coords={"y": np.arange(1, 3)})["y"]
 da2 = da2.assign_coords(h=da2.y**2)
 print(da2)
-grid.interp(da2, "X", keep_coords=True)
+grid.interp(da2, "X")
 ```
 
 So far we have just discussed simple grids (i.e. regular grids with a single

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -7,6 +7,14 @@
 
 ### Breaking Changes
 
+- Removed the deprecated `keep_coords` keyword argument from grid operations
+  (`Grid.interp`, `Grid.diff`, `Grid.min`, `Grid.max`, `Grid.cumsum`, etc.) and from
+  `apply_as_grid_ufunc`. The behavior is now always that formerly given by
+  `keep_coords=True`: coordinates compatible with the output (including non-dimension
+  coordinates) are preserved. Passing `keep_coords=` now raises a `TypeError`
+  ([#382](https://github.com/xgcm/xgcm/issues/382), [#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  By [Henri Drake](https://github.com/hdrake).
+
 ### Internal Changes
 
 - Migrate development workflow to Pixi ([#691](https://github.com/xgcm/xgcm/pull/691))

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -12,7 +12,7 @@
   `apply_as_grid_ufunc`. The behavior is now always that formerly given by
   `keep_coords=True`: coordinates compatible with the output (including non-dimension
   coordinates) are preserved. Passing `keep_coords=` now raises a `TypeError`
-  ([#382](https://github.com/xgcm/xgcm/issues/382), [#XXX](https://github.com/xgcm/xgcm/pull/XXX)).
+  ([#382](https://github.com/xgcm/xgcm/issues/382), [#745](https://github.com/xgcm/xgcm/pull/745)).
   By [Henri Drake](https://github.com/hdrake).
 
 ### Internal Changes

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -11,7 +11,10 @@
   (`Grid.interp`, `Grid.diff`, `Grid.min`, `Grid.max`, `Grid.cumsum`, etc.) and from
   `apply_as_grid_ufunc`. The behavior is now always that formerly given by
   `keep_coords=True`: coordinates compatible with the output (including non-dimension
-  coordinates) are preserved. Passing `keep_coords=` now raises a `TypeError`
+  coordinates) are preserved. Note that this silently changes the **default** output of
+  `Grid.interp`, `Grid.diff`, `Grid.min`, `Grid.max`, `Grid.cumsum`, `Grid.derivative`,
+  and `Grid.cumint`, which previously dropped non-dimension coordinates from the result
+  and now retains them. Passing `keep_coords=` now raises a `TypeError`
   ([#382](https://github.com/xgcm/xgcm/issues/382), [#745](https://github.com/xgcm/xgcm/pull/745)).
   By [Henri Drake](https://github.com/hdrake).
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -14,7 +14,7 @@
   coordinates) are preserved. Note that this silently changes the **default** output of
   `Grid.interp`, `Grid.diff`, `Grid.min`, `Grid.max`, `Grid.cumsum`, `Grid.derivative`,
   and `Grid.cumint`, which previously dropped non-dimension coordinates from the result
-  and now retains them. Passing `keep_coords=` now raises a `TypeError`
+  and now retains them. Passing `keep_coords=` now raises a `ValueError`
   ([#382](https://github.com/xgcm/xgcm/issues/382), [#745](https://github.com/xgcm/xgcm/pull/745)).
   By [Henri Drake](https://github.com/hdrake).
 

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -606,7 +606,6 @@ class Grid:
         data: Union[xr.DataArray, Dict[str, xr.DataArray]],
         axis,
         to=None,
-        keep_coords=False,
         metric_weighted: Optional[
             Union[str, Iterable[str], Dict[str, Union[str, Iterable[str]]]]
         ] = None,
@@ -690,7 +689,6 @@ class Grid:
                 self,
                 array,
                 axis=[(ax_name,)],
-                keep_coords=keep_coords,
                 dask=dask,
                 map_overlap=map_overlap,
                 other_component=other_component,
@@ -1043,7 +1041,6 @@ class Grid:
         boundary=None,
         fill_value=None,
         metric_weighted=None,
-        keep_coords: bool = False,
     ) -> xr.DataArray:
         """
         Cumulatively sum a DataArray, transforming to the intermediate axis
@@ -1172,7 +1169,6 @@ class Grid:
                 [coordless],
                 grid=self,
                 boundary_width=ax_boundary_width,
-                keep_coords=keep_coords,
                 # The only newly position-shifted (core) dim is the result dim;
                 # its coordinate must come from the grid. Coordinates on all other
                 # (non-core) dims should be preserved from the input array. #496.
@@ -1293,8 +1289,6 @@ class Grid:
             The value to use in the boundary condition with `boundary='fill'`.
         vector_partner : dict, optional
             A single key (string), value (DataArray)
-        keep_coords : boolean, optional
-            Preserves compatible coordinates. False by default.
 
         Returns
         -------

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -627,6 +627,13 @@ class Grid:
             If not specified, the `default_shifts` stored in each Axis object will be used for that axis.
         """
 
+        # TODO - remove deprecation handling in a future release
+        if "keep_coords" in kwargs:
+            raise TypeError(
+                "The 'keep_coords' argument has been removed. Coordinates "
+                "compatible with the output are now always preserved."
+            )
+
         if isinstance(axis, str):
             axis = [axis]
 
@@ -1041,6 +1048,7 @@ class Grid:
         boundary=None,
         fill_value=None,
         metric_weighted=None,
+        **kwargs,
     ) -> xr.DataArray:
         """
         Cumulatively sum a DataArray, transforming to the intermediate axis
@@ -1092,6 +1100,17 @@ class Grid:
 
         >>> grid.max(da, ["X", "Y"], fill_value={"X": 0, "Y": 100})
         """
+
+        # TODO - remove deprecation handling in a future release
+        if "keep_coords" in kwargs:
+            raise TypeError(
+                "The 'keep_coords' argument has been removed. Coordinates "
+                "compatible with the output are now always preserved."
+            )
+        if kwargs:
+            raise TypeError(
+                f"cumsum() got unexpected keyword argument(s): {list(kwargs)}"
+            )
 
         if isinstance(axis, str):
             axis = [axis]

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -629,7 +629,7 @@ class Grid:
 
         # TODO - remove deprecation handling in a future release
         if "keep_coords" in kwargs:
-            raise TypeError(
+            raise ValueError(
                 "The 'keep_coords' argument has been removed. Coordinates "
                 "compatible with the output are now always preserved."
             )
@@ -1103,7 +1103,7 @@ class Grid:
 
         # TODO - remove deprecation handling in a future release
         if "keep_coords" in kwargs:
-            raise TypeError(
+            raise ValueError(
                 "The 'keep_coords' argument has been removed. Coordinates "
                 "compatible with the output are now always preserved."
             )

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -713,7 +713,7 @@ def apply_as_grid_ufunc(
 
     # TODO - remove deprecation handling in a future release
     if "keep_coords" in kwargs:
-        raise TypeError(
+        raise ValueError(
             "The 'keep_coords' argument has been removed. Coordinates "
             "compatible with the output are now always preserved."
         )

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -711,6 +711,13 @@ def apply_as_grid_ufunc(
     xarray.apply_ufunc
     """
 
+    # TODO - remove deprecation handling in a future release
+    if "keep_coords" in kwargs:
+        raise TypeError(
+            "The 'keep_coords' argument has been removed. Coordinates "
+            "compatible with the output are now always preserved."
+        )
+
     if grid is None:
         raise ValueError("Must provide a grid object to describe the Axes")
     # ? Why is this actually an optional input? This causes some mypy issues on pre-commit too.

--- a/xgcm/grid_ufunc.py
+++ b/xgcm/grid_ufunc.py
@@ -1,6 +1,5 @@
 import re
 import string
-import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -618,7 +617,6 @@ def apply_as_grid_ufunc(
     boundary_width: Optional[Mapping[str, Tuple[int, int]]] = None,
     boundary: Optional[Union[str, Mapping[str, str]]] = None,
     fill_value: Optional[Union[float, Mapping[str, float]]] = None,
-    keep_coords: bool = True,
     dask: Literal["forbidden", "parallelized", "allowed"] = "forbidden",
     map_overlap: bool = False,
     pad_before_func: bool = True,
@@ -865,7 +863,7 @@ def apply_as_grid_ufunc(
     out_core_dim_names = set(d for arg in out_core_dims for d in arg)
     input_args = [_maybe_unpack_vector_component(arg) for arg in args]
     results_with_coords = _reattach_coords(
-        results, grid, boundary_width, keep_coords, out_core_dim_names, input_args
+        results, grid, boundary_width, out_core_dim_names, input_args
     )
 
     # xr.apply_ufunc moves core dims to the end and never moves them back, so
@@ -1196,7 +1194,6 @@ def _reattach_coords(
     results: Sequence[xr.DataArray],
     grid: "Grid",
     boundary_width,
-    keep_coords: bool,
     out_core_dim_names: Optional[Set[str]] = None,
     input_args: Optional[Sequence[xr.DataArray]] = None,
 ) -> List[xr.DataArray]:
@@ -1248,18 +1245,6 @@ def _reattach_coords(
                 )
             else:
                 raise
-
-        if not keep_coords:
-            # TODO I don't like the `keep_coords` argument in general and think it should be removed for clarity.
-            warnings.warn(
-                "The keep_coords keyword argument is being deprecated - in future it will be removed "
-                "entirely, and the behaviour will always be that currently given by keep_coords=True.",
-                category=DeprecationWarning,
-            )
-
-            # Drop any non-dimension coordinates on the output
-            non_dim_coords = [coord for coord in res.coords if coord not in res.dims]
-            res = res.drop_vars(non_dim_coords)
 
         results_with_coords.append(res)
 

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -376,13 +376,29 @@ def test_keep_coords(funcname, gridtype):
 
 def test_keep_coords_removed():
     # The `keep_coords` kwarg was removed in v1.0.0 (GH #382); passing it now
-    # raises a TypeError rather than emitting a deprecation warning.
+    # raises an informative TypeError rather than emitting a deprecation
+    # warning. Check all three entry points that guard against it: the 1D
+    # grid-ufunc dispatch (interp/diff/min/max/...), cumsum (separate code
+    # path), and apply_as_grid_ufunc (public entry point).
+    from xgcm.grid_ufunc import apply_as_grid_ufunc
+
     ds, coords, metrics = datasets_grid_metric("B")
     ds = ds.assign_coords(yt_bis=ds["yt"], xt_bis=ds["xt"])
     grid = Grid(ds, coords=coords, metrics=metrics, autoparse_metadata=False)
     for axis_name in grid.axes.keys():
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="has been removed"):
             grid.diff(ds.tracer, axis_name, keep_coords=False)
+        with pytest.raises(TypeError, match="has been removed"):
+            grid.cumsum(ds.tracer, axis_name, keep_coords=False)
+    with pytest.raises(TypeError, match="has been removed"):
+        apply_as_grid_ufunc(
+            lambda x: x,
+            ds.tracer,
+            axis=[("X",)],
+            grid=grid,
+            signature="(X:center)->(X:center)",
+            keep_coords=False,
+        )
 
 
 @pytest.mark.parametrize("funcname", ["interp", "diff"])

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -369,26 +369,19 @@ def test_keep_coords(funcname, gridtype):
             if set(ds[c].dims).issubset(result.dims) and c not in result.dims
         ]
 
-        if funcname in ["integrate", "average"]:
-            assert set(result.coords) == set(base_coords + augmented_coords)
-        else:
-            assert set(result.coords) == set(base_coords)
-
-        # TODO: why is the behavior different for integrate and average?
-        if funcname not in ["integrate", "average"]:
-            result = func(ds.tracer, axis_name, keep_coords=False)
-            assert set(result.coords) == set(base_coords)
-
-            result = func(ds.tracer, axis_name, keep_coords=True)
-            assert set(result.coords) == set(base_coords + augmented_coords)
+        # Non-dimension coordinates compatible with the output are now always
+        # preserved (former keep_coords=True behavior, GH #382).
+        assert set(result.coords) == set(base_coords + augmented_coords)
 
 
-def test_keep_coords_deprecation():
+def test_keep_coords_removed():
+    # The `keep_coords` kwarg was removed in v1.0.0 (GH #382); passing it now
+    # raises a TypeError rather than emitting a deprecation warning.
     ds, coords, metrics = datasets_grid_metric("B")
     ds = ds.assign_coords(yt_bis=ds["yt"], xt_bis=ds["xt"])
     grid = Grid(ds, coords=coords, metrics=metrics, autoparse_metadata=False)
     for axis_name in grid.axes.keys():
-        with pytest.warns(DeprecationWarning):
+        with pytest.raises(TypeError):
             grid.diff(ds.tracer, axis_name, keep_coords=False)
 
 
@@ -428,9 +421,8 @@ def test_preserve_input_noncore_coords(funcname, use_dask):
     if use_dask:
         v = v.chunk({"time": 4})
 
-    # keep_coords=True so that non-dimension coordinates are retained on output
-    # (the default drops them, which is unrelated to the #496 clobbering bug).
-    out = getattr(grid, funcname)(v, "X", keep_coords=True)
+    # Non-dimension coordinates are always retained on output (GH #382).
+    out = getattr(grid, funcname)(v, "X")
 
     # The user's modified non-core dimension coord must survive (dtype AND values).
     assert out.time.dtype == np.float32
@@ -484,7 +476,7 @@ def test_cumsum_preserves_input_noncore_coords(use_dask):
     if use_dask:
         v = v.chunk({"time": 4})
 
-    out = grid.cumsum(v, "X", to="left", keep_coords=True)
+    out = grid.cumsum(v, "X", to="left")
 
     # The user's modified non-core dimension coord must survive (dtype AND values).
     assert out.time.dtype == np.float32

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -376,21 +376,21 @@ def test_keep_coords(funcname, gridtype):
 
 def test_keep_coords_removed():
     # The `keep_coords` kwarg was removed in v1.0.0 (GH #382); passing it now
-    # raises an informative TypeError rather than emitting a deprecation
-    # warning. Check all three entry points that guard against it: the 1D
-    # grid-ufunc dispatch (interp/diff/min/max/...), cumsum (separate code
-    # path), and apply_as_grid_ufunc (public entry point).
+    # raises an informative ValueError (per the deprecation policy in GH #696)
+    # rather than emitting a deprecation warning. Check all three entry points
+    # that guard against it: the 1D grid-ufunc dispatch (interp/diff/min/max/...),
+    # cumsum (separate code path), and apply_as_grid_ufunc (public entry point).
     from xgcm.grid_ufunc import apply_as_grid_ufunc
 
     ds, coords, metrics = datasets_grid_metric("B")
     ds = ds.assign_coords(yt_bis=ds["yt"], xt_bis=ds["xt"])
     grid = Grid(ds, coords=coords, metrics=metrics, autoparse_metadata=False)
     for axis_name in grid.axes.keys():
-        with pytest.raises(TypeError, match="has been removed"):
+        with pytest.raises(ValueError, match="has been removed"):
             grid.diff(ds.tracer, axis_name, keep_coords=False)
-        with pytest.raises(TypeError, match="has been removed"):
+        with pytest.raises(ValueError, match="has been removed"):
             grid.cumsum(ds.tracer, axis_name, keep_coords=False)
-    with pytest.raises(TypeError, match="has been removed"):
+    with pytest.raises(ValueError, match="has been removed"):
         apply_as_grid_ufunc(
             lambda x: x,
             ds.tracer,

--- a/xgcm/test/test_metrics.py
+++ b/xgcm/test/test_metrics.py
@@ -264,7 +264,9 @@ def test_get_metric_with_conditions_04a():
     interp_metric = grid.interp(ds.dx_t, "Y")
     expected_metric = (interp_metric * ds.dy_n).reset_coords(drop=True)
 
-    xr.testing.assert_allclose(get_metric, expected_metric)
+    # Grid operations now always preserve compatible non-dimension coords
+    # (GH #382); compare the metric values by dropping them.
+    xr.testing.assert_allclose(get_metric.reset_coords(drop=True), expected_metric)
 
 
 def test_get_metric_with_conditions_04b():
@@ -280,7 +282,9 @@ def test_get_metric_with_conditions_04b():
     interp_metric_2 = grid.interp(ds.dy_t, "Y")
     expected_metric = (interp_metric_1 * interp_metric_2).reset_coords(drop=True)
 
-    xr.testing.assert_allclose(get_metric, expected_metric)
+    # Grid operations now always preserve compatible non-dimension coords
+    # (GH #382); compare the metric values by dropping them.
+    xr.testing.assert_allclose(get_metric.reset_coords(drop=True), expected_metric)
 
 
 def test_set_metric():

--- a/xgcm/test/test_metrics_ops.py
+++ b/xgcm/test/test_metrics_ops.py
@@ -115,7 +115,9 @@ def _run_single_derivative_test(grid, axis, fld, dx):
     dvar_dx = grid.derivative(fld, axis)
     expected = grid.diff(fld, axis) / dx
 
-    assert dvar_dx.equals(expected.reset_coords(drop=True))
+    # Grid operations now always preserve compatible non-dimension coords
+    # (GH #382); compare the underlying values by dropping them on both sides.
+    assert dvar_dx.reset_coords(drop=True).equals(expected.reset_coords(drop=True))
 
 
 class TestDerivatives:


### PR DESCRIPTION
## What

Removes the deprecated `keep_coords` keyword argument from all grid operations (`Grid.interp`, `Grid.diff`, `Grid.min`, `Grid.max`, `Grid.cumsum`, etc.) and from `apply_as_grid_ufunc`. The behavior is now unconditionally that formerly given by `keep_coords=True`: coordinates compatible with the output (including non-dimension coordinates) are preserved.

**Note the silent default change:** `Grid.interp`/`diff`/`min`/`max`/`cumsum` (and `derivative`/`cumint`) previously defaulted to `keep_coords=False`, so their output now *retains* non-dimension coordinates it used to drop.

Passing `keep_coords=` now raises an informative `ValueError` ("The 'keep_coords' argument has been removed. Coordinates compatible with the output are now always preserved.") via explicit guards at all three entry points (`_1d_grid_ufunc_dispatch`, `Grid.cumsum`, `apply_as_grid_ufunc`), following the deprecation policy established in #696 (which specifies `ValueError`, consistently with #746) — rather than leaking xarray's misleading internal error (`apply_ufunc() got an unexpected keyword argument 'keep_coords'. Did you mean 'keep_attrs'?`).

This is a **Breaking Change** for the v1.0.0 release (#733, roadmap §A).

## Why

`keep_coords` has been deprecation-warned since v0.9.0, with the stated plan that the behavior would always become that of `keep_coords=True`. This finalizes that removal. See #382.

## Tests

- Simplified `test_keep_coords` to assert compatible coords are always preserved.
- `test_keep_coords_removed` asserts the informative `ValueError` (matching on the message, not xarray internals) at all three guard sites: a dispatch-routed op (`grid.diff`), `grid.cumsum`, and `apply_as_grid_ufunc` directly.
- Updated metric/derivative value comparisons that had relied on the old default dropping non-dimension coords (coords reset on both sides; values still compared exactly).
- Full suite green (`pixi run tests`: 4204 passed, 2 skipped, 50 xfailed, 8 xpassed), lint clean.

Closes #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)