### PR TITLE
Fix vector pad ignoring rotation for bare-DataArray other_component (#748)

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -33,6 +33,17 @@
 
 ### Bugfixes
 
+- Fix `xgcm.padding.pad(..., other_component=...)` (and hence vector `Grid.diff`/`Grid.interp`)
+  silently ignoring the vector rotation when the component is passed as a bare `DataArray`
+  rather than a `{axis_name: DataArray}` dict. On a `face_connections` grid the bare form padded
+  the component scalar-style, so the halo across a rotated (axis-swapping) or reversed seam was
+  wrong and no error was raised — e.g. on ECCO LLC90 the global convergence sum of the advective
+  heat flux was `-1.6e9` (bare) versus `0` (dict). The bare form now recovers the component's axis
+  from its own staggering and runs the same rotation/sign-flip logic as the dict form, giving
+  identical output, and raises a clear error when the axis cannot be inferred (e.g. a cell-centre
+  field) ([#748](https://github.com/xgcm/xgcm/issues/748)).
+  By [Henri Drake](https://github.com/hdrake).
+
 - Fix `Grid.transform(..., method="conservative")` falsely raising `NotImplementedError`
   ("not yet supported for multi-dimensional targets") when a 1-dimensional target was combined
   with an explicit `target_dim` longer than one character: the guard tested the length of the

--- a/xgcm/padding.py
+++ b/xgcm/padding.py
@@ -67,6 +67,36 @@ def _strip_all_coords(obj: xr.DataArray):
         return obj_stripped
 
 
+def _infer_vector_component_axis(grid: Grid, da: xr.DataArray) -> str:
+    """Infer the grid axis a vector component is aligned with from its staggering.
+
+    A velocity component is edge-staggered (``left``/``right``/``inner``/
+    ``outer``) on exactly its own axis and cell-``center`` on every orthogonal
+    axis, so the single edge axis unambiguously names the component. Used to
+    orient the vector sign-flips when a bare ``DataArray`` is padded with an
+    ``other_component`` but the caller did not wrap it in a
+    ``{axis_name: DataArray}`` dict.
+    """
+    edge_axes = []
+    for axname, axis in grid.axes.items():
+        try:
+            position, _ = axis._get_position_name(da)
+        except KeyError:
+            # The component has no dimension on this axis; skip it.
+            continue
+        if position != "center":
+            edge_axes.append(axname)
+    if len(edge_axes) == 1:
+        return edge_axes[0]
+    raise ValueError(
+        "Could not unambiguously infer the axis of the vector component being "
+        f"padded from its staggered position (edge axes found: {edge_axes}). "
+        "Pass the component as a `{axis_name: DataArray}` dict so its "
+        "orientation is explicit, e.g. "
+        "`pad({'Y': v}, ..., other_component={'X': u})`."
+    )
+
+
 def _pad_face_connections(
     da: Union[xr.DataArray, Dict[str, xr.DataArray]],
     grid: Grid,
@@ -87,6 +117,16 @@ def _pad_face_connections(
     if isinstance(da, dict):
         isvector = True
         vectoraxis, da = da.popitem()
+    elif other_component is not None:
+        # A bare DataArray supplied together with `other_component` is a vector
+        # component whose axis was not named (the dict key is what names it).
+        # Treat it as a vector and recover the axis from its own staggering so the
+        # rotation/sign-flip logic below runs identically to the dict form.
+        # Without this the component is padded scalar-style and the halo across a
+        # rotated (axis-swapping) or reversed face-connection seam is silently
+        # wrong -- `other_component` is ignored entirely.
+        isvector = True
+        vectoraxis = _infer_vector_component_axis(grid, da)
     else:
         isvector = False
 

--- a/xgcm/test/test_padding.py
+++ b/xgcm/test/test_padding.py
@@ -905,6 +905,106 @@ class TestPaddingFaceConnection:
         xr.testing.assert_allclose(u_result, u_expected)
         xr.testing.assert_allclose(v_result, v_expected)
 
+    def test_vector_bare_matches_dict_swap_axis(
+        self, boundary_width, ds_faces, fill_value
+    ):
+        # Regression: a bare `DataArray` padded with `other_component` must
+        # produce the SAME halo as the equivalent `{axis: DataArray}` dict input.
+        # Previously the bare form silently ignored `other_component` and padded
+        # scalar-style, so the halo across the rotated (axis-swapping) seam was
+        # wrong -- the component was never replaced by the neighbour's orthogonal
+        # component and never sign-flipped. The dict form is the verified oracle
+        # (pinned to hand-computed halos by the tests above).
+        face_connections = {
+            "face": {
+                0: {"X": (None, (1, "Y", False))},
+                1: {"Y": ((0, "X", False), None)},
+            }
+        }
+        grid = Grid(ds_faces, face_connections=face_connections)
+        u = ds_faces.u.reset_coords(drop=True).reset_index(ds_faces.u.dims, drop=True)
+        v = ds_faces.v.reset_coords(drop=True).reset_index(ds_faces.v.dims, drop=True)
+        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        kw = dict(
+            grid=grid,
+            boundary_width=boundary_width,
+            boundary="fill",
+            fill_value=fill_value,
+        )
+
+        u_dict = pad({"X": u}, other_component={"Y": v}, **kw)
+        u_bare = pad(u, other_component={"Y": v}, **kw)
+        xr.testing.assert_identical(u_bare, u_dict)
+
+        v_dict = pad({"Y": v}, other_component={"X": u}, **kw)
+        v_bare = pad(v, other_component={"X": u}, **kw)
+        xr.testing.assert_identical(v_bare, v_dict)
+
+    def test_vector_bare_matches_dict_same_axis_reverse(
+        self, boundary_width, ds_faces, fill_value
+    ):
+        # As above but for a same-axis *reversed* seam (the sign-flip that a
+        # bipolar/tripolar fold applies to the normal component): exercises the
+        # `vectoraxis == axname` branch, which the bare form must reach too.
+        face_connections = {
+            "face": {
+                0: {"X": (None, (1, "X", True))},
+                1: {"X": (None, (0, "X", True))},
+            }
+        }
+        grid = Grid(ds_faces, face_connections=face_connections)
+        u = ds_faces.u.reset_coords(drop=True).reset_index(ds_faces.u.dims, drop=True)
+        v = ds_faces.v.reset_coords(drop=True).reset_index(ds_faces.v.dims, drop=True)
+        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        kw = dict(
+            grid=grid,
+            boundary_width=boundary_width,
+            boundary="fill",
+            fill_value=fill_value,
+        )
+
+        u_dict = pad({"X": u}, other_component={"Y": v}, **kw)
+        u_bare = pad(u, other_component={"Y": v}, **kw)
+        xr.testing.assert_identical(u_bare, u_dict)
+
+        v_dict = pad({"Y": v}, other_component={"X": u}, **kw)
+        v_bare = pad(v, other_component={"X": u}, **kw)
+        xr.testing.assert_identical(v_bare, v_dict)
+
+    def test_bare_vector_pad_ambiguous_axis_raises(
+        self, boundary_width, ds_faces, fill_value
+    ):
+        # A cell-centre (tracer-like) field is not a vector component -- its axis
+        # cannot be inferred from staggering -- so a bare pad with
+        # `other_component` must raise rather than silently guess.
+        face_connections = {
+            "face": {
+                0: {"X": (None, (1, "X", False))},
+                1: {"X": ((0, "X", False), None)},
+            }
+        }
+        grid = Grid(ds_faces, face_connections=face_connections)
+        tracer = xr.DataArray(
+            np.zeros(
+                (
+                    ds_faces.sizes["face"],
+                    ds_faces.sizes["x"],
+                    ds_faces.sizes["y"],
+                )
+            ),
+            dims=["face", "x", "y"],
+        )
+        boundary_width["Y"] = boundary_width.get("Y", (0, 0))
+        with pytest.raises(ValueError, match="infer the axis"):
+            pad(
+                tracer,
+                grid=grid,
+                boundary_width=boundary_width,
+                boundary="fill",
+                fill_value=fill_value,
+                other_component={"X": ds_faces.u},
+            )
+
     def test_vector_face_connections_right_right_swap_axis(
         self, boundary_width, ds_faces, fill_value
     ):


### PR DESCRIPTION
Closes #748.

## Problem

`xgcm.padding.pad(..., other_component=...)` — and therefore vector `Grid.diff` / `Grid.interp` — **silently ignored the vector rotation when the component was passed as a bare `DataArray`** (rather than a `{axis_name: DataArray}` dict) across a `face_connections` seam. The component was padded scalar-style, so the halo across a rotated (axis-swapping) or reversed seam was wrong, and no error was raised.

In `_pad_face_connections` the `isvector` flag that gates the entire rotation/sign-flip branch was set *only* when the input was a dict; a bare `DataArray` left it `False`, dropping `other_component` entirely. `Grid.diff`/`Grid.interp` hit this path because `grid_ufunc._pad_then_rechunk` forwards the bare argument straight to `pad`. The existing rotated-vector tests all pass the component as a dict, so the bare path was untested.

Real-world symptom on ECCO LLC90 — global convergence sum of the vertically-integrated advective heat flux (must be identical regardless of input form):

| input form | `sum(diff(u,"X",oc=v) + diff(v,"Y",oc=u))` |
| --- | --- |
| `{axis: DataArray}` dict | `0.000000e+00` (exact) |
| bare `DataArray` | `-1.642547e+09` (wrong) |

## Fix

When `da` is a bare `DataArray` and `other_component` is provided, treat it as a vector and recover its axis from its own staggering — a velocity component is edge-staggered (`left`/`right`/`inner`/`outer`) on exactly its own axis and cell-`center` on every orthogonal axis, so the single edge axis names the component unambiguously. The bare form then runs the *identical*, already-verified dict code path, giving byte-identical output. If the axis cannot be inferred (e.g. a cell-centre field, or a corner point edge-staggered on two axes) a clear `ValueError` is raised rather than silently guessing.

After the fix the LLC90 bare-form global convergence sum is `0.000000e+00`, matching the dict form.

## Tests

Adds three parametrized regression tests to `TestPaddingFaceConnection`:

- `test_vector_bare_matches_dict_swap_axis` — rotated (axis-swapping) seam: bare output must equal dict output for both components.
- `test_vector_bare_matches_dict_same_axis_reverse` — same-axis *reversed* seam (the fold sign-flip on the normal component).
- `test_bare_vector_pad_ambiguous_axis_raises` — a cell-centre field raises rather than guessing.

All three fail on `master` (bare halos are wrong; the raise path does not trigger) and pass with this change. The full `test_padding.py` / `test_faceconnections.py` / `test_grid_ufunc.py` suites remain green (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
