### PR TITLE
docs: document which pixi environment runs the doc notebooks (#667)

### DIFF
--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -51,6 +51,19 @@ pixi run docs-serve
 ```
 This will start a live preview running on `http://127.0.0.1:8000/`
 
+## Running the documentation notebooks
+
+The documentation notebooks that live directly in `docs/` (`transform.ipynb` and
+`grid_metrics.ipynb`) run in the `docs` pixi environment, which bundles everything
+they need (including `numba` for `Grid.transform` and `matplotlib`). To open them
+interactively in Jupyter Lab:
+
+```
+pixi run notebooks
+```
+
+This launches Jupyter Lab rooted at the `docs` folder.
+
 ## How to release a new version of xgcm (for maintainers only)
 
 The process of releasing at this point is very easy.

--- a/docs/grid_metrics.ipynb
+++ b/docs/grid_metrics.ipynb
@@ -2,6 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "source": "> **Running this notebook:** This notebook requires `matplotlib` for plotting and `netcdf4` to read the example dataset, in addition to xgcm's core dependencies. If you have cloned the repo, the pixi `docs` environment includes everything needed — launch Jupyter with `pixi run notebooks`. Otherwise install `xgcm`, `matplotlib`, and `netcdf4` into your environment.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Grid Metrics\n",

--- a/docs/transform.ipynb
+++ b/docs/transform.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Running this notebook:** This notebook requires `numba` (used by `Grid.transform`) and `matplotlib`, in addition to xgcm's core dependencies. If you have cloned the repo, the pixi `docs` environment includes everything needed — launch Jupyter with `pixi run notebooks`. Otherwise install `xgcm`, `numba`, and `matplotlib` into your environment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Transforming Vertical Coordinates\n",
     "\n",
     "A common need in the analysis of ocean and atmospheric data is to transform the vertical coordinate from its original coordinate (e.g. depth) to a new coordinate (e.g. density).\n",

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -44,6 +44,10 @@
 - Migrate documentation to mkdocs ([#691](https://github.com/xgcm/xgcm/pull/691))
   By [Nick Hodgskin](https://github.com/VeckoTheGecko).
 
+- Document which environment runs the documentation notebooks (`transform.ipynb`, `grid_metrics.ipynb`).
+  The existing `docs` pixi environment now bundles Jupyter Lab and can be launched with `pixi run notebooks`,
+  and the notebooks and contributor guide note the required dependencies ([#667](https://github.com/xgcm/xgcm/issues/667)).
+
 ### Bugfixes
 
 - Grid operations (e.g. `Grid.interp`, `Grid.diff`, `Grid.cumsum`) no longer drop or clobber non-core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,11 +207,13 @@ mkdocstrings-python=">=1.18.2"
 pyyaml=">=6.0.1"
 matplotlib="*"
 graphviz = "*"
+jupyterlab=">=4"
 
 [tool.pixi.feature.docs.tasks]
 _setup-graphviz = "dot -c"
 docs-serve = { cmd = "mkdocs serve --livereload", depends-on = ['_setup-graphviz'] }
 docs-build = { cmd = "mkdocs build", depends-on = ['_setup-graphviz'] }
+notebooks = "jupyter lab docs"
 
 [tool.pixi.feature.pre-commit.dependencies]
 pre_commit = "*"


### PR DESCRIPTION
## Summary

Issue #667 asked for a consolidated conda `environment_notebooks.yml` for running the documentation notebooks. Instead of adding a conda file, this PR leans into the existing pixi setup: the `docs` pixi environment already bundles every dependency the doc notebooks need (`numba` via the `extra` feature, `matplotlib` via `docs`, `netcdf4` via `notebooks`). The real gap was that this was undocumented — nothing told a user which environment runs `transform.ipynb` / `grid_metrics.ipynb`.

## Changes

- **`pyproject.toml`**: add `jupyterlab>=4` to `[tool.pixi.feature.docs.pypi-dependencies]` and a `notebooks = "jupyter lab docs"` task under `[tool.pixi.feature.docs.tasks]`, so `pixi run notebooks` opens Jupyter Lab rooted at `docs/`.
- **`docs/transform.ipynb`**: add a top markdown note stating it needs `numba` and `matplotlib`, and how to launch via `pixi run notebooks`.
- **`docs/grid_metrics.ipynb`**: add a top markdown note stating it needs `matplotlib` and `netcdf4`.
- **`docs/contributor_guide.md`**: add a "Running the documentation notebooks" section.
- **`docs/whats-new.md`**: add a Documentation entry referencing #667.

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbLtjojoSQCrQY7s3Xt56f