### PR TITLE
Raise ValueError when the same dimension is assigned to multiple Axis positions

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -5,6 +5,14 @@
 
 ### New Features
 
+### Bug Fixes
+
+- `Axis` now raises a `ValueError` immediately if the same dimension name is
+  assigned to more than one position (e.g. `{'center': 'x', 'outer': 'x'}`),
+  rather than silently accepting the invalid configuration
+  ([#634](https://github.com/xgcm/xgcm/issues/634)).
+  By [Mike German](https://github.com/steps-re).
+
 ### Breaking Changes
 
 - Removed the deprecated `keep_coords` keyword argument from grid operations

--- a/xgcm/axis.py
+++ b/xgcm/axis.py
@@ -90,6 +90,21 @@ class Axis:
                 raise ValueError(
                     f"Could not find dimension `{dim}` (for the `{pos}` position on axis `{name}`) in input dataset."
                 )
+
+        # check that no dimension is assigned to more than one position
+        dims = list(coords.values())
+        seen = set()
+        duplicates = set()
+        for dim in dims:
+            if dim in seen:
+                duplicates.add(dim)
+            seen.add(dim)
+        if duplicates:
+            raise ValueError(
+                f"The same dimension cannot be assigned to multiple positions on axis `{name}`. "
+                f"Duplicate dimension(s): {sorted(duplicates)}"
+            )
+
         self._coords = coords
 
         # set default position shifts

--- a/xgcm/test/test_axis.py
+++ b/xgcm/test/test_axis.py
@@ -50,6 +50,18 @@ class TestInit:
                 coords={"center": "lat", "left": "lon"},
             )
 
+    def test_duplicate_dims(self, periodic_1d):
+        """Test that assigning the same dimension to two positions raises an error."""
+        ds, _, _ = periodic_1d
+        with pytest.raises(
+            ValueError, match="same dimension cannot be assigned to multiple positions"
+        ):
+            Axis(
+                name="X",
+                ds=ds,
+                coords={"center": "XC", "outer": "XC"},
+            )
+
     def test_invalid_args(self, periodic_1d):
         ds, _, _ = periodic_1d
 

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -51,9 +51,11 @@ class TestInvalidGrid:
             ds, *_ = datasets_grid_metric("C")
             Grid(ds, coords={"ax1": {"center": "XGEEEEEEEE"}}, autoparse_metadata=False)
 
-    @pytest.mark.xfail(reason="Not yet implemented")
-    def test_duplicate_values(self):
-        with pytest.raises(ValueError):
+    def test_duplicate_dims_same_axis(self):
+        """Same dimension assigned to two positions on one axis must raise."""
+        with pytest.raises(
+            ValueError, match="same dimension cannot be assigned to multiple positions"
+        ):
             ds, *_ = datasets_grid_metric("C")
             Grid(
                 ds,
@@ -61,6 +63,9 @@ class TestInvalidGrid:
                 autoparse_metadata=False,
             )
 
+    @pytest.mark.xfail(reason="Cross-axis duplicate dimension check not yet implemented")
+    def test_duplicate_dims_cross_axis(self):
+        """Same dimension assigned across two different axes must raise."""
         with pytest.raises(ValueError):
             ds, *_ = datasets_grid_metric("C")
             Grid(

--- a/xgcm/test/test_grid.py
+++ b/xgcm/test/test_grid.py
@@ -63,7 +63,9 @@ class TestInvalidGrid:
                 autoparse_metadata=False,
             )
 
-    @pytest.mark.xfail(reason="Cross-axis duplicate dimension check not yet implemented")
+    @pytest.mark.xfail(
+        reason="Cross-axis duplicate dimension check not yet implemented"
+    )
     def test_duplicate_dims_cross_axis(self):
         """Same dimension assigned across two different axes must raise."""
         with pytest.raises(ValueError):


### PR DESCRIPTION
Closes #634.

## What

`Axis.__init__` silently accepted coordinates dicts where the same dimension name appeared under two different positions, e.g.

```python
Grid(ds, coords={'X': {'center': 'x', 'outer': 'x'}})
```

This produces a nonsensical axis and causes confusing downstream errors. The fix adds an explicit check immediately after the existing per-position validation loop and raises a clear `ValueError` naming the duplicate dimension(s).

## Changes

- `xgcm/axis.py`: add duplicate-dimension check in `Axis.__init__`, after the position/dim validation loop.
- `xgcm/test/test_axis.py`: add `test_duplicate_dims` to `TestInit`.
- `xgcm/test/test_grid.py`: split the existing `xfail` `test_duplicate_values` into `test_duplicate_dims_same_axis` (now passes) and `test_duplicate_dims_cross_axis` (remains `xfail` — cross-axis detection is not yet implemented).
- `docs/whats-new.md`: Bug Fixes entry for v0.10.0.

## Tests

```
pytest xgcm/test/test_axis.py xgcm/test/test_grid.py::TestInvalidGrid -v
# 24 passed, 1 xfailed
```

This is part of the broader 1.0 input-validation / stricter-checks effort.