### PR TITLE
Fix spurious interpolation warnings in Grid.get_metric

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -7,6 +7,15 @@
 
 ### Bug Fixes
 
+- `Grid.get_metric` (and the operations built on it, e.g. `Grid.integrate` and
+  `Grid.average`) no longer emits spurious "Metric ... being interpolated ..."
+  `UserWarning`s when an exact-position metric combination exists but is not the
+  first candidate tried. The search now looks for an exact-position match across
+  all candidate combinations before falling back to interpolation, and warns at
+  most once. The returned metric is unchanged
+  ([#758](https://github.com/xgcm/xgcm/pull/758)).
+  By [Henri Drake](https://github.com/hdrake).
+
 - `Axis` now raises a `ValueError` immediately if the same dimension name is
   assigned to more than one position (e.g. `{'center': 'x', 'outer': 'x'}`),
   rather than silently accepting the invalid configuration

--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -499,38 +499,64 @@ class Grid:
                 )
                 metric_vars = self.interp_like(mv, array, "extend", None)
         else:
+            # Search ALL candidate axis combinations for an exact-position match
+            # (Condition 3) before considering interpolation (Condition 4).
+            # Otherwise, position-mismatched combinations iterated before the
+            # exact one would emit spurious "being interpolated" warnings even
+            # though an exact-position metric exists (GH #756).
+            #
+            # `interp_fallback` records the combination to interpolate if NO
+            # exact-position combination exists for any candidate. To keep
+            # existing interpolation results (e.g. test_get_metric_with_
+            # conditions_04*) unchanged, it deliberately mirrors the pre-fix
+            # selection: the LAST product combination of the FIRST candidate
+            # whose metrics are all present. Once that first present candidate
+            # has been fully scanned without an exact match, the fallback is
+            # locked so later candidates cannot overwrite it.
+            interp_fallback = None
+            interp_fallback_locked = False
             for axis_combinations in iterate_axis_combinations(axes):
                 try:
                     # will raise KeyError if the axis combination is not in metrics
                     possible_metric_vars = [
                         self._metrics[ac] for ac in axis_combinations
                     ]
-                    for possible_combinations in itertools.product(
-                        *possible_metric_vars
-                    ):
-                        metric_dims = set(
-                            [d for mv in possible_combinations for d in mv.dims]
-                        )
-                        if metric_dims.issubset(array_dims):
-                            # Condition 3: use provided metrics with matching dimensions to calculate for required metric
-                            metric_vars = possible_combinations
-                            break
-                        else:
-                            # Condition 4: metrics in the wrong position (must interpolate before multiplying)
-                            possible_dims = [pc.dims for pc in possible_combinations]
-                            warnings.warn(
-                                f"Metric at {array.dims} being interpolated from metrics at dimensions {possible_dims}. Boundary value set to 'extend'."
-                            )
-                            metric_vars = tuple(
-                                self.interp_like(pc, array, "extend", None)
-                                for pc in possible_combinations
-                            )
-                    if metric_vars is not None:
-                        # return the product of the metrics
-                        metric_vars = functools.reduce(operator.mul, metric_vars, 1)
-                        break
                 except KeyError:
-                    pass
+                    continue
+                for possible_combinations in itertools.product(*possible_metric_vars):
+                    metric_dims = set(
+                        [d for mv in possible_combinations for d in mv.dims]
+                    )
+                    if metric_dims.issubset(array_dims):
+                        # Condition 3: use provided metrics with matching
+                        # dimensions to calculate the required metric.
+                        metric_vars = functools.reduce(
+                            operator.mul, possible_combinations, 1
+                        )
+                        break
+                    if not interp_fallback_locked:
+                        interp_fallback = possible_combinations
+                if metric_vars is not None:
+                    break
+                # Only the first present candidate seeds the interpolation
+                # fallback (see comment above).
+                interp_fallback_locked = True
+
+            if metric_vars is None and interp_fallback is not None:
+                # Condition 4: no exact-position combination exists anywhere, so
+                # interpolate the fallback metrics (warning exactly once).
+                possible_dims = [pc.dims for pc in interp_fallback]
+                warnings.warn(
+                    f"Metric at {array.dims} being interpolated from metrics at dimensions {possible_dims}. Boundary value set to 'extend'."
+                )
+                metric_vars = functools.reduce(
+                    operator.mul,
+                    tuple(
+                        self.interp_like(pc, array, "extend", None)
+                        for pc in interp_fallback
+                    ),
+                    1,
+                )
         if metric_vars is None:
             raise KeyError(
                 f"Unable to find any combinations of metrics for array dims {array_dims!r} and axes {axes!r}"

--- a/xgcm/test/test_metrics.py
+++ b/xgcm/test/test_metrics.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+import warnings
 
 import numpy as np
 import pytest
@@ -285,6 +286,46 @@ def test_get_metric_with_conditions_04b():
     # Grid operations now always preserve compatible non-dimension coords
     # (GH #382); compare the metric values by dropping them.
     xr.testing.assert_allclose(get_metric.reset_coords(drop=True), expected_metric)
+
+
+@pytest.mark.parametrize(
+    "data_var, z_metrics, expected_dz",
+    [
+        # tracer point (xt, yt, zt): an exact-position thickness (dz_t) exists,
+        # but it is registered *after* several wrong-position thicknesses, so the
+        # pre-fix code warned once per wrong-position combination tried first.
+        ("tracer", ["dz_w", "dz_w_ne", "dz_w_n", "dz_w_e", "dz_t"], "dz_t"),
+        # w point (xt, yt, zw): exact-position thickness (dz_w) exists but is
+        # registered after the wrong-position dz_t.
+        ("wt", ["dz_t", "dz_w"], "dz_w"),
+    ],
+)
+def test_get_metric_no_spurious_interpolation_warning(data_var, z_metrics, expected_dz):
+    # Regression test (GH #756): when get_metric must combine metrics from
+    # separate axes (the `else` branch), an exact-position combination that is
+    # not the first one iterated should be found WITHOUT emitting bogus
+    # "being interpolated" UserWarnings for the earlier, wrong-position
+    # combinations. The returned metric must still be the exact-position product.
+    ds, coords, _ = datasets_grid_metric("C")
+    # Register area (X, Y) and thickness (Z) metrics but NOT a combined
+    # (X, Y, Z) volume, forcing get_metric into the axis-combination search.
+    metrics = {
+        ("X", "Y"): ["area_t", "area_n", "area_e", "area_ne"],
+        ("Z",): z_metrics,
+    }
+    grid = Grid(ds, coords=coords, metrics=metrics, autoparse_metadata=False)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        metric = grid.get_metric(ds[data_var], ("X", "Y", "Z"))
+
+    interpolation_warnings = [
+        str(w.message) for w in caught if "being interpolated" in str(w.message)
+    ]
+    assert interpolation_warnings == []
+
+    expected = (ds["area_t"] * ds[expected_dz]).reset_coords(drop=True)
+    xr.testing.assert_allclose(metric.reset_coords(drop=True), expected)
 
 
 def test_set_metric():


### PR DESCRIPTION


Fixes #757

## What / why

`Grid.get_metric`'s multi-axis combination search (the `else` branch) warned
eagerly whenever a position-mismatched metric combination was tried, without
stopping the loop. When an exact-position combination existed but was not the
first candidate iterated, the correct metric was still returned, but one or more
bogus `UserWarning: Metric at ... being interpolated ...` messages were emitted
first. This is user-facing noise via `Grid.integrate` / `Grid.average` and
implies (falsely) that an interpolated metric was used.

## The fix

Restructure the `else` branch so it searches **all** candidate axis
combinations for an exact-position match (`metric_dims.issubset(array_dims)`)
before considering interpolation, and warns **at most once** when interpolation
is genuinely required (no exact-position combination exists for any candidate).

To avoid changing any existing interpolation result, the interpolation fallback
is chosen deterministically to mirror the pre-fix selection: the last product
combination of the first candidate whose metrics are all present. This is
documented in a code comment. The return contract (product of metrics via
`functools.reduce(operator.mul, ...)`), the `_get_dims_from_axis` validation, the
`KeyError`-swallowing over `iterate_axis_combinations`, and the final
`raise KeyError` are all preserved.

## Tests

Added `test_get_metric_no_spurious_interpolation_warning` in
`xgcm/test/test_metrics.py`, parametrized over a tracer point and a w point.
Each registers area `(X, Y)` and thickness `(Z)` metrics (built by reusing the
`datasets_grid_metric` synthetic grid) with the exact-position thickness placed
after wrong-position ones, then asserts that no "being interpolated" warning is
emitted and that the returned metric equals the exact-position product. The test
fails on `master` (spurious warnings) and passes with this change. The full
`test_metrics.py` + `test_metrics_ops.py` suite passes unchanged.

## Changelog

Added a Bug Fixes entry under the unreleased v0.10.0 section of
`docs/whats-new.md`.

## How I used AI

I was manually reviewing #756 (see https://app.reviewnb.com/xgcm/xgcm/pull/756/discussion/) when I noticed a nonsensical warning, which Claude Code (Opus 4.8 model) helped me trace to this bug. I then asked Claude to open an Issue describing the bug and a minimal draft PR that fixes it and adds a test that passes only after test. I already reviewed the summarized changes as the agent was working on the task but will extensively review all code changes manually.
