### PR TITLE
Document why get_metric prefers interpolating an exact-axes metric over sub-axis composition (#759)

### DIFF
--- a/xgcm/grid.py
+++ b/xgcm/grid.py
@@ -493,7 +493,23 @@ class Grid:
                     metric_vars = mv
                     break
             if metric_vars is None:
-                # Condition 2: interpolate metric with matching axis to desired dimensions
+                # Condition 2: a metric is registered under exactly these axes but
+                # not at the array's position, so interpolate it onto that position.
+                #
+                # This deliberately takes priority over Condition 3 below (building
+                # the metric by multiplying separately-registered sub-axis metrics,
+                # e.g. dx * dy). On curvilinear grids the true cell area/volume is
+                # generally not the product of the 1-D widths (area != dx * dy): an
+                # explicitly-registered exact-axes metric encodes that true geometry,
+                # so interpolating it preserves the curvature information at the cost
+                # of some interpolation error, whereas a sub-axis product would
+                # silently assume separability and discard it. An exact-axes metric
+                # is therefore preferred even when it must be interpolated; sub-axis
+                # composition (Condition 3) is only reached when no metric is
+                # registered under these exact axes at all. The warning below flags
+                # that interpolation occurred, so a user who would rather compose
+                # from exact-position widths can register those widths without an
+                # exact-axes area/volume metric. See GH #759.
                 warnings.warn(
                     f"Metric at {array.dims} being interpolated from metrics at dimensions {mv.dims}. Boundary value set to 'extend'."
                 )


### PR DESCRIPTION
## What

Adds an inline comment to `Grid.get_metric` documenting why **Condition 2**
(interpolate a metric registered under the exact requested axes onto the array's
position) is deliberately preferred over **Condition 3** (compose the metric by
multiplying separately-registered sub-axis widths, e.g. `dx * dy`).

## Why

Raised in #759. On curvilinear grids the true cell area/volume is generally
**not** the product of the 1-D widths (`area != dx * dy`) — which is precisely
why a separate area/volume metric exists. An explicitly-registered exact-axes
metric encodes that true geometry, so interpolating it (with the existing
`UserWarning`) preserves the curvature information, whereas composing from
sub-axis widths would silently assume separability and discard it.

The current priority is therefore intended, not a bug — it was initially
reported as one in #759 before the curvilinear consideration surfaced. This PR
records the rationale inline so it is not mistaken for a bug again, and notes
that a user who would rather compose from exact-position widths can simply
register those widths without an exact-axes metric (the existing warning flags
when interpolation happens).

## Scope

Comment only — **no behavior change**. Existing behavior is already covered by
`test_get_metric_with_conditions_02a`/`02b`, so no new tests, and no changelog
entry (nothing user-facing changes).

Closes #759.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNLwMuTGgTVvTdEgMwj3WH
