### PR TITLE
Render $...$ math in example notebooks

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,14 +1,16 @@
 window.MathJax = {
   tex: {
-    inlineMath: [["\\(", "\\)"]],
-    displayMath: [["\\[", "\\]"]],
+    // Hand-written .md pages go through pymdownx.arithmatex (generic), which
+    // emits \(...\) / \[...\]. Notebook pages rendered by mkdocs-jupyter leave
+    // math as raw $...$ / $$...$$, so accept both delimiter styles.
+    inlineMath: [["\\(", "\\)"], ["$", "$"]],
+    displayMath: [["\\[", "\\]"], ["$$", "$$"]],
     processEscapes: true,
     processEnvironments: true
-  },
-  options: {
-    ignoreHtmlClass: ".*|",
-    processHtmlClass: "arithmatex"
   }
+  // No ignoreHtmlClass/processHtmlClass restriction: the arithmatex spans and
+  // the notebook cells both need typesetting, and MathJax skips code/pre by
+  // default so literal $ in code is left alone.
 };
 
 document$.subscribe(() => {


### PR DESCRIPTION
## Problem

Inline and display math in the `xgcm-examples` notebooks renders as raw LaTeX source (e.g. `$\zeta = \frac{\partial v}{\partial x} - \frac{\partial u}{\partial y}$`) instead of typeset math. This affects **every** example notebook, e.g. [05_tripolar_fold](https://xgcm.readthedocs.io/en/latest/xgcm-examples/05_tripolar_fold/) and [02_nemo_idealized](https://xgcm.readthedocs.io/en/latest/xgcm-examples/02_nemo_idealized/).

## Cause

The docs produce math two ways, but `docs/javascripts/mathjax.js` was tuned for only one:

- **Hand-written `.md` pages** use `pymdownx.arithmatex` (`generic: true`), which converts `$…$` into `<span class="arithmatex">\(…\)</span>`.
- **Notebook pages** are rendered by `mkdocs-jupyter`, which leaves math as raw `$…$` / `$$…$$` in plain `<p>` elements — no `arithmatex` class.

The config only recognized `\(…\)` delimiters and, via `ignoreHtmlClass: ".*|"` / `processHtmlClass: "arithmatex"`, only typeset elements with class `arithmatex`. Notebook math matched neither, so MathJax skipped it. (The `tex2jax` block nbconvert embeds in each notebook page is inert — MathJax 3 doesn't read the v2 `MathJax.Hub`/`tex2jax` API.)

## Fix

Accept both delimiter styles and drop the arithmatex-only class restriction:

```js
tex: {
  inlineMath:  [["\\(", "\\)"], ["$", "$"]],
  displayMath: [["\\[", "\\]"], ["$$", "$$"]],
  ...
}
// no ignoreHtmlClass/processHtmlClass — arithmatex spans and notebook cells both typeset
```

Arithmatex spans (`\(…\)`) and notebook cells (`$…$`) are now both typeset. MathJax skips `code`/`pre` by default, so literal `$` in code blocks is unaffected. The one behavioral change is that a stray literal `$` in prose on a `.md` page could now be treated as a math delimiter — the standard tradeoff for enabling `$` math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)